### PR TITLE
refactor: 토큰 저장 위치 변경

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -16,27 +16,9 @@ const createClient = (config?: AxiosRequestConfig) => {
 
   axiosInstance.interceptors.request.use(
     (config) => {
-      const token = getToken();
-      if (token) {
-        config.headers.Authorization = token;
-      }
       return config;
     },
     (error) => {
-      return Promise.reject(error);
-    }
-  );
-
-  axiosInstance.interceptors.response.use(
-    (response) => {
-      return response;
-    },
-    (error) => {
-      if (error.response && error.response.status === 401) {
-        removeToken();
-        window.location.href = "/login";
-        return Promise.reject(error);
-      }
       return Promise.reject(error);
     }
   );

--- a/src/app/[userid]/admin/page.tsx
+++ b/src/app/[userid]/admin/page.tsx
@@ -1,18 +1,16 @@
-"use client";
+import AdminLayout from "@/app/components/admin/AdminLayout";
+import RequireAuth from "@/app/components/RequireAuthPage";
 
-import { usePathname } from "next/navigation";
-import AdminLayout from "../../components/admin/AdminLayout";
-import RequireAuth from "../../components/RequireAuthPage";
+interface Props {
+  params: {
+    userid: string;
+  };
+}
 
-export default function Page() {
-  const pathname = usePathname();
-  let userid = "";
-  if (pathname) {
-    userid = pathname.split("/")[1];
-  }
+export default function Page({ params }: Props) {
   return (
-    <RequireAuth url={userid}>
-      <AdminLayout userid={userid} />
+    <RequireAuth url={params.userid}>
+      <AdminLayout userid={params.userid} />
     </RequireAuth>
   );
 }

--- a/src/app/[userid]/page.tsx
+++ b/src/app/[userid]/page.tsx
@@ -1,14 +1,11 @@
-"use client";
+import NonAdminLayout from "@/app/components/non-admin/NonAdminLayout";
 
-import { usePathname } from "next/navigation";
-import NonAdminLayout from "../components/non-admin/NonAdminLayout";
+interface Props {
+  params: {
+    userid: string;
+  };
+}
 
-export default function Page() {
-  const pathname = usePathname();
-  let userid = "";
-  if (pathname) {
-    userid = pathname.split("/")[1];
-  }
-
-  return <NonAdminLayout userid={userid} />;
+export default function Page({ params }: Props) {
+  return <NonAdminLayout userid={params.userid} />;
 }

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+import { query } from "@/util/database";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userid, password } = await request.json();
+
+    if (!userid || !password) {
+      return NextResponse.json(
+        { message: "아이디와 비밀번호를 입력해주세요." },
+        { status: 400 }
+      );
+    }
+
+    const result = await query("SELECT * FROM users WHERE userid = $1", [
+      userid,
+    ]);
+
+    if (
+      result.length > 0 &&
+      (await bcrypt.compare(password, result[0].password))
+    ) {
+      const payload = { userid: result[0].userid };
+      const secret = process.env.JWT_SECRET;
+
+      if (!secret) {
+        throw new Error("JWT_SECRET is not defined in .env.local");
+      }
+
+      const token = jwt.sign(payload, secret, { expiresIn: "12h" });
+
+      const response = NextResponse.json(
+        {
+          message: "login success",
+          user: {
+            userid: result[0].userid,
+          },
+        },
+        { status: 200 }
+      );
+
+      response.cookies.set({
+        name: "token",
+        value: token,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        maxAge: undefined, // session cookie
+        expires: undefined, // session cookie
+        path: "/",
+      });
+
+      return response;
+    }
+
+    return NextResponse.json(
+      { message: "Invalid ID or Password" },
+      { status: 401 }
+    );
+  } catch (e: any) {
+    console.error("Login error:", e);
+    return NextResponse.json({ message: "Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/users/logout/route.ts
+++ b/src/app/api/users/logout/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  try {
+    const response = NextResponse.json(
+      { message: "logout success" },
+      { status: 200 }
+    );
+
+    response.cookies.set({
+      name: "token",
+      value: "",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      maxAge: 0,
+      path: "/",
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Logout error:", error);
+    return NextResponse.json({ message: "Logout Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import jwt from "jsonwebtoken";
+
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.cookies.get("token")?.value;
+
+    if (!token) {
+      return NextResponse.json(null, { status: 401 });
+    }
+
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error("JWT_SECRET is not defined");
+    }
+
+    const decoded = jwt.verify(token, secret) as { userid: string };
+
+    return NextResponse.json({ userid: decoded.userid });
+  } catch (error) {
+    return NextResponse.json(null, { status: 401 });
+  }
+}

--- a/src/app/components/LoginForm.tsx
+++ b/src/app/components/LoginForm.tsx
@@ -12,11 +12,10 @@ export default function LoginForm() {
   const [userid2, setUserid2] = useState("");
   const [email, setEmail] = useState("");
 
-  const { login, loading, setLoading } = useAuth();
+  const { login, isPending } = useAuth();
 
   const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setLoading(true);
     const data = {
       userid: userid,
       password: password,
@@ -67,7 +66,7 @@ export default function LoginForm() {
             />
           </Form.Group>
           <Button variant="dark" type="submit" style={{ marginRight: "1vw" }}>
-            {loading ? <LoadingIcon /> : "Log In"}
+            {isPending ? <LoadingIcon /> : "Log In"}
           </Button>
           <Button variant="light" onClick={() => setShowForgot(!showForgot)}>
             I forgot my password:(

--- a/src/app/components/LoginForm.tsx
+++ b/src/app/components/LoginForm.tsx
@@ -12,7 +12,7 @@ export default function LoginForm() {
   const [userid2, setUserid2] = useState("");
   const [email, setEmail] = useState("");
 
-  const { login, isPending } = useAuth();
+  const { login, isLoggingIn } = useAuth();
 
   const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -66,7 +66,7 @@ export default function LoginForm() {
             />
           </Form.Group>
           <Button variant="dark" type="submit" style={{ marginRight: "1vw" }}>
-            {isPending ? <LoadingIcon /> : "Log In"}
+            {isLoggingIn ? <LoadingIcon /> : "Log In"}
           </Button>
           <Button variant="light" onClick={() => setShowForgot(!showForgot)}>
             I forgot my password:(

--- a/src/app/components/RequireAuthPage.tsx
+++ b/src/app/components/RequireAuthPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import useAuth from "@/hooks/useAuth";
 import Link from "next/link";
 
 export default function RequireAuth({
@@ -8,20 +8,15 @@ export default function RequireAuth({
   children,
 }: {
   url: string;
-  children: any;
+  children: React.ReactNode;
 }) {
-  const [isAuthorized, setIsAuthorized] = useState(false);
+  const { user, isLoading } = useAuth();
 
-  useEffect(() => {
-    const token = sessionStorage.getItem("token");
-    const userid = sessionStorage.getItem("userid");
+  // 로딩 중에는 아무것도 보여주지 않음
+  if (isLoading) return null;
 
-    if (token && url === userid) {
-      setIsAuthorized(true);
-    }
-  }, [url]);
-
-  if (!isAuthorized) {
+  // 비로그인 상태이거나 다른 사용자의 admin 페이지 접근 시도
+  if (!user || user.userid !== url) {
     return (
       <div>
         You cannot access this page without logging in.
@@ -30,6 +25,5 @@ export default function RequireAuth({
     );
   }
 
-  // if token and userid are valid, render the children
   return children;
 }

--- a/src/app/components/admin/AdminLayout.tsx
+++ b/src/app/components/admin/AdminLayout.tsx
@@ -12,6 +12,7 @@ import {
 import { useState, useEffect } from "react";
 import axios from "axios";
 import AdminPage from "./AdminPage";
+import useAuth from "@/hooks/useAuth";
 
 interface Props {
   userid: string;
@@ -25,18 +26,12 @@ export default function AdminLayout({ userid }: Props) {
   const [currentPW, setCurrentPW] = useState("");
   const [newPW, setNewPW] = useState("");
   const [confirmPW, setConfirmPW] = useState("");
+  const { logout } = useAuth();
 
   const getUser = async () => {
     const res = await axios.get(`/api/get/user?userid=${userid}`);
     setUsername(res.data[0].username);
     setEmail(res.data[0].email);
-  };
-
-  const handleLogout = () => {
-    // delete session
-    sessionStorage.removeItem("userid");
-    sessionStorage.removeItem("token");
-    window.location.href = `/${userid}`;
   };
 
   const handleClose = () => setShow(false);
@@ -103,7 +98,7 @@ export default function AdminLayout({ userid }: Props) {
       <Row style={{ textAlign: "right" }}>
         <Col>
           <ButtonGroup>
-            <Button variant="dark" onClick={handleLogout}>
+            <Button variant="dark" onClick={() => logout()}>
               로그아웃
             </Button>
             <Button variant="light" onClick={handleOpen}>

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,3 +1,4 @@
 export const queryKeys = {
   tabs: (params: { userid: string }) => ["tabs", params],
+  auth: () => ["auth", "me"] as const,
 } as const;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,22 +1,65 @@
-import { useState } from "react";
-import { fetchLogin } from "../api/auth.api";
-import { LoginForm } from "../models/user.model";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { LoginForm } from "@/models/user.model";
+import { get, post } from "@/api/http";
+import { queryKeys } from "@/constants/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface LoginResponse {
+  message: string;
+  user: {
+    userid: string;
+  };
+}
 
 export default function useAuth() {
-  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const queryClient = useQueryClient();
 
-  const login = (data: LoginForm) => {
-    setLoading(true);
-    fetchLogin(data)
-      .then((res) => {
-        if (!res) return;
-        sessionStorage.setItem("userid", res.data.userid);
-        sessionStorage.setItem("token", res.data.token);
+  const { data: user, isLoading } = useQuery({
+    queryKey: queryKeys.auth(),
+    queryFn: async () => {
+      try {
+        const response = await get<{ userid: string }>(`/users/me`);
+        return response;
+      } catch {
+        return null;
+      }
+    },
+  });
 
-        window.location.href = `/${res.data.userid}/admin`;
-      })
-      .then(() => setLoading(false));
-  };
+  const { mutate: login, isPending: isLoggingIn } = useMutation({
+    mutationFn: async (data: LoginForm) => {
+      return await post<LoginResponse>(`/users/login`, data);
+    },
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.auth() });
+      router.push(`/${response.user.userid}/admin`);
+    },
+    onError: (error: Error) => {
+      console.log("Login Failed: ", error);
+    },
+  });
 
-  return { login, loading, setLoading };
+  const { mutate: logout, isPending: isLoggingOut } = useMutation({
+    mutationFn: async () => {
+      const currentUserId = user?.userid;
+      const response = await post<{ message: string }>(`/users/logout`);
+      return { response, currentUserId };
+    },
+    onSuccess: ({ currentUserId }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.auth() });
+      if (currentUserId) {
+        router.push(`/${currentUserId}`);
+      } else {
+        router.push("/");
+      }
+    },
+    onError: (error: Error) => {
+      console.log("Logout Failed: ", error);
+    },
+  });
+
+  return { user, isLoading, login, isLoggingIn, logout, isLoggingOut };
 }


### PR DESCRIPTION
resolves #6, #9

jwt 토큰 세션 스토리지에 저장하던 거 삭제하고 쿠키에 담도록 변경. 
로그인과 로그아웃 앱라우터와 리액트 쿼리로 변경. 
페이지 컴포넌트 usePathname 안 써도 url 받아올 수 있었는데 왜 그동안 바보같이 이걸 클라이언트 컴포넌트로 만들어놨나 
