### PR TITLE
feat: Public과 Admin의 폰트 크기 통일. home 레이아웃 수정.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "endOfLine": "auto"
 }

--- a/src/app/components/public/PublicContents.tsx
+++ b/src/app/components/public/PublicContents.tsx
@@ -17,6 +17,7 @@ export default function PublicContents({ userid, tid }: Props) {
       <CardContent className="prose max-w-none dark:prose-invert">
         {content && (
           <div
+            className="ql-editor prose-headings:!text-inherit prose-p:!text-inherit"
             dangerouslySetInnerHTML={{
               __html: content,
             }}

--- a/src/app/components/public/PublicHome.tsx
+++ b/src/app/components/public/PublicHome.tsx
@@ -14,7 +14,7 @@ export default function PublicHome({ homeData }: Props) {
 
   return (
     <Card className="mx-2 md:mx-8 lg:w-[1024px]">
-      <CardContent className="flex flex-col items-center justify-center gap-5 md:flex-row">
+      <CardContent className="flex flex-col items-start justify-center gap-5 md:flex-row">
         {homeData.img && (
           <CardContent className="flex-1">
             <Image
@@ -29,7 +29,7 @@ export default function PublicHome({ homeData }: Props) {
           </CardContent>
         )}
         <CardContent
-          className="prose max-w-none flex-1 dark:prose-invert"
+          className="ql-editor prose max-w-none flex-1 dark:prose-invert prose-headings:!text-inherit prose-p:!text-inherit"
           dangerouslySetInnerHTML={{ __html: homeData.intro ?? "" }}
         />
       </CardContent>


### PR DESCRIPTION
# Features
## PublicHome 레이아웃 변경
- 기존: 이미지와 자기소개가 `flex items-center`로 가운데에 맞춰 정렬.
- 문제점: 자기소개 글이 길어질 경우 이미지 위에 공백이 생김. 
- 수정: `items-start`로 변경하여 이미지와 글 모두 위에 붙게 함. 이로써 불필요한 공백은 모두 화면 아래로 내려보냄. 특히 뷰포트가 md 이상이지만 그리 크지 않을 경우에 효과적. 

# Bug Fix
## 저번에 `ql-editor` 커스텀 Public 적용 빼먹음 
`AdminEditor` 에서 커스터마이징한 `ql-editor`의 헤더 스타일을 `PublicHome`과 `PublicContents`에도 적용. 
## `.prettierrc` 줄바꿈 관련 추가 
```
"endOfLine": "auto"
```
난 언제나 여기서만 작업했는데 왜 새삼스럽게 `Delete ␍eslint[prettier/prettier]`에러가 떴는지 잘 모르겠음. 
`.prettierrc` 에 저거 한 줄 추가해서 해결함. 


# Others
