### PR TITLE
fix: Tabs 및 자식 레이아웃 수정

### DIFF
--- a/src/app/[locale]/[userid]/page.tsx
+++ b/src/app/[locale]/[userid]/page.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export default function Page({ params }: Props) {
   return (
-    <div className="flex flex-col items-center p-0">
+    <div className="flex flex-col items-center">
       <Header params={params} />
       <PublicContainer userid={params.userid} />
       <Footer />

--- a/src/app/components/InitPage.tsx
+++ b/src/app/components/InitPage.tsx
@@ -24,6 +24,8 @@ import {
 import useAuth from "@/hooks/useAuth";
 import { useResetPassword } from "@/hooks/useResetPW";
 
+import UsageGuide from "./UsageGuide";
+
 export default function InitPage() {
   const t = useTranslations("initpage");
   const [showResetForm, setShowResetForm] = useState(false);
@@ -82,9 +84,9 @@ export default function InitPage() {
   };
 
   return (
-    <div>
-      <Tabs defaultValue="login" className="w-[400px]">
-        <TabsList className="grid w-full grid-cols-2">
+    <div className="mx-auto flex w-full max-w-lg flex-col gap-4 p-2 md:max-w-xl">
+      <Tabs defaultValue="login" className="mx-0 w-full max-w-none md:mx-0">
+        <TabsList className="grid grid-cols-2">
           <TabsTrigger value="login">{t("login")}</TabsTrigger>
           <TabsTrigger value="signup">{t("signup")}</TabsTrigger>
         </TabsList>
@@ -309,27 +311,7 @@ export default function InitPage() {
           </Card>
         </TabsContent>
       </Tabs>
-
-      <div className="mb-2 flex flex-col gap-1 p-4">
-        <h5 className="text-lg font-bold">{t("try")}</h5>
-        <span className="inline-flex items-center gap-1">
-          <p className="text-sm">{t("checkOut")}</p>
-          <a
-            href="https://easiest-cv.vercel.app/tutorial"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-blue-500 hover:underline"
-          >
-            {t("professorCV")}
-          </a>
-        </span>
-        <p className="text-sm">{t("or")}</p>
-        <p className="text-sm">{t("use")}</p>
-        <span className="rounded-md border bg-[#f8f9fa] p-1">
-          <p className="font-mono text-sm text-gray-700">{t("demoId")}</p>
-          <p className="font-mono text-sm text-gray-700">{t("demoPW")}</p>
-        </span>
-      </div>
+      <UsageGuide />
     </div>
   );
 }

--- a/src/app/components/UsageGuide.tsx
+++ b/src/app/components/UsageGuide.tsx
@@ -1,0 +1,28 @@
+import { useTranslations } from "next-intl";
+
+export default function UsageGuide() {
+  const t = useTranslations("UsageGuide");
+
+  return (
+    <div className="flex flex-col gap-1">
+      <h5 className="text-lg font-bold">{t("try")}</h5>
+      <span className="inline-flex items-center gap-1">
+        <p className="text-sm">{t("checkOut")}</p>
+        <a
+          href="https://easiest-cv.vercel.app/tutorial"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-500 hover:underline"
+        >
+          {t("professorCV")}
+        </a>
+      </span>
+      <p className="text-sm">{t("or")}</p>
+      <p className="text-sm">{t("use")}</p>
+      <span className="rounded-md border bg-[#f8f9fa] p-1">
+        <p className="font-mono text-sm text-gray-700">{t("demoId")}</p>
+        <p className="font-mono text-sm text-gray-700">{t("demoPW")}</p>
+      </span>
+    </div>
+  );
+}

--- a/src/app/components/UsageGuide.tsx
+++ b/src/app/components/UsageGuide.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 
 export default function UsageGuide() {
-  const t = useTranslations("UsageGuide");
+  const t = useTranslations("usageGuide");
 
   return (
     <div className="flex flex-col gap-1">

--- a/src/app/components/admin/AdminPDF.tsx
+++ b/src/app/components/admin/AdminPDF.tsx
@@ -14,8 +14,8 @@ export default function AdminPDF({ userid }: Props) {
   const { homeData, mutateUploadPdf, isPdfPending } = useHome(userid);
 
   return (
-    <Card className="mx-2 md:mx-8 lg:w-[1024px]">
-      <CardContent className="prose max-w-none dark:prose-invert">
+    <Card>
+      <CardContent className="prose dark:prose-invert">
         <Label htmlFor="pdf">{t("pdfAttach")}</Label>
         <Input
           id="pdf"

--- a/src/app/components/admin/AdminTabs.tsx
+++ b/src/app/components/admin/AdminTabs.tsx
@@ -18,8 +18,8 @@ export default function AdminTabs({ userid }: Props) {
   const { tabs } = useTabs(userid);
 
   return (
-    <Tabs defaultValue="home" className="mx-2 md:mx-8 lg:mx-auto lg:w-[1024px]">
-      <TabsList className="flex w-full">
+    <Tabs defaultValue="home">
+      <TabsList>
         <TabsTrigger value="home">Home</TabsTrigger>
         {tabs &&
           tabs.map((tab) => (

--- a/src/app/components/common/Tabs.tsx
+++ b/src/app/components/common/Tabs.tsx
@@ -5,7 +5,17 @@ import * as React from "react";
 
 import { cn } from "@/util/classname";
 
-const Tabs = TabsPrimitive.Root;
+const Tabs = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Root
+    ref={ref}
+    className={cn("mx-2 md:mx-8 lg:mx-auto lg:max-w-[1024px]", className)}
+    {...props}
+  />
+));
+Tabs.displayName = TabsPrimitive.Root.displayName;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -14,7 +24,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-zinc-100 p-1 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+      "flex min-h-11 flex-wrap items-center justify-center gap-1 rounded-lg bg-zinc-100 p-1 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
       className,
     )}
     {...props}

--- a/src/app/components/public/PublicContainer.tsx
+++ b/src/app/components/public/PublicContainer.tsx
@@ -10,15 +10,17 @@ export default function PublicContainer({ userid }: { userid: string }) {
   const { user, isLoading, isError } = useUser(userid);
 
   return (
-    <div className="">
-      <Title title={user?.username || userid} />
-      {isLoading ? (
-        <LoadingPage />
-      ) : isError || !user ? (
-        <NoUserPage />
-      ) : (
-        <PublicTabs userid={userid} />
-      )}
+    <div className="flex w-full justify-center px-4">
+      <div className="w-full max-w-[1024px]">
+        <Title title={user?.username || userid} />
+        {isLoading ? (
+          <LoadingPage />
+        ) : isError || !user ? (
+          <NoUserPage />
+        ) : (
+          <PublicTabs userid={userid} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/components/public/PublicContents.tsx
+++ b/src/app/components/public/PublicContents.tsx
@@ -13,7 +13,7 @@ export default function PublicContents({ userid, tid }: Props) {
   const content = tabs.find((tab) => tab.tid === tid)?.contents;
 
   return (
-    <Card className="mx-2 md:mx-8 lg:w-[1024px]">
+    <Card>
       <CardContent className="prose max-w-none dark:prose-invert">
         {content && (
           <div

--- a/src/app/components/public/PublicContents.tsx
+++ b/src/app/components/public/PublicContents.tsx
@@ -13,17 +13,22 @@ export default function PublicContents({ userid, tid }: Props) {
   const content = tabs.find((tab) => tab.tid === tid)?.contents;
 
   return (
-    <Card>
-      <CardContent className="prose max-w-none dark:prose-invert">
+    <Card className="w-full">
+      <CardContent className="prose w-full dark:prose-invert">
         {content && (
           <div
             className="ql-editor prose-headings:!text-inherit prose-p:!text-inherit"
             dangerouslySetInnerHTML={{
               __html: content,
             }}
-          ></div>
+          />
         )}
       </CardContent>
     </Card>
   );
 }
+
+//   <CardContent className="prose max-w-none dark:prose-invert">
+//     {content && (
+//       <div
+//         className="ql-editor prose-headings:!text-inherit prose-p:!text-inherit"

--- a/src/app/components/public/PublicHome.tsx
+++ b/src/app/components/public/PublicHome.tsx
@@ -1,9 +1,8 @@
 import Image from "next/image";
 
+import { Card, CardContent } from "@/app/components/common/Card";
+import LoadingPage from "@/app/components/LoadingPage";
 import { HomeData } from "@/models/home.model";
-
-import { Card, CardContent } from "../common/Card";
-import LoadingPage from "../LoadingPage";
 
 interface Props {
   homeData: HomeData;
@@ -13,7 +12,7 @@ export default function PublicHome({ homeData }: Props) {
   if (!homeData) return <LoadingPage />;
 
   return (
-    <Card className="mx-2 md:mx-8 lg:w-[1024px]">
+    <Card>
       <CardContent className="flex flex-col items-start justify-center gap-5 md:flex-row">
         {homeData.img && (
           <CardContent className="flex-1">

--- a/src/app/components/public/PublicHome.tsx
+++ b/src/app/components/public/PublicHome.tsx
@@ -13,7 +13,7 @@ export default function PublicHome({ homeData }: Props) {
 
   return (
     <Card>
-      <CardContent className="flex flex-col items-start justify-center gap-5 md:flex-row">
+      <CardContent className="flex flex-col items-center justify-center gap-5 md:flex-row md:items-start">
         {homeData.img && (
           <CardContent className="flex-1">
             <Image

--- a/src/app/components/public/PublicTabs.tsx
+++ b/src/app/components/public/PublicTabs.tsx
@@ -27,7 +27,7 @@ export default function PublicTabs({ userid }: Props) {
 
   return (
     <Tabs defaultValue="home">
-      <TabsList className="flex w-full">
+      <TabsList>
         <TabsTrigger value="home">Home</TabsTrigger>
         {tabs &&
           tabs.map((tab) => (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -42,14 +42,16 @@
     "description": "If you click this button below, your password will be reset and the temporary password will be sent to your email.",
     "signupIdDescription": "This ID will be your domain. You CANNOT change it later.",
     "signupEmailDescription": "If you forget your password, you will receive email here.",
-    "try": "Want to try?",
-    "or": "Or",
-    "use": "Use this demo account:",
-    "demoId": "ID: tutorial",
-    "demoPW": "PW: easiestcv",
-    "checkOut": "Check out",
-    "professorCV": "Professor John Doe's CV →",
     "isLoggingIn": "Please wait..."
+  },
+  "usageGuide": {
+    "try": "Want to try it out?",
+    "use": "Log in with this demo account:",
+    "or": "Or",
+    "demoId": "ID: tutorial",
+    "demoPW": "Password: easiestcv",
+    "checkOut": "Check out this page: ",
+    "professorCV": "Professor John Doe's CV →"
   },
   "admin": {
     "pdfAttach": "Attach PDF",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -42,14 +42,16 @@
     "description": "아래 버튼을 클릭하시면 비밀번호가 초기화되고 임시 비밀번호가 이메일로 발송됩니다.",
     "signupIdDescription": "이 ID로 당신의 사이트 주소가 만들어집니다. ID는 나중에 변경할 수 없습니다.",
     "signupEmailDescription": "비밀번호 분실 시 이 이메일 주소로 임시 비밀번호가 발송됩니다.",
+    "isLoggingIn": "잠시만 기다려 주세요..."
+  },
+  "usageGuide": {
     "try": "사용해보고 싶으신가요?",
     "use": "이 테스트 계정으로 로그인해보세요:",
     "or": "또는",
     "demoId": "아이디: tutorial",
     "demoPW": "비밀번호: easiestcv",
     "checkOut": "여기를 둘러보세요: ",
-    "professorCV": "John Doe 교수님의 이력서 →",
-    "isLoggingIn": "잠시만 기다려 주세요..."
+    "professorCV": "John Doe 교수님의 이력서 →"
   },
   "admin": {
     "pdfAttach": "PDF 첨부",


### PR DESCRIPTION
# Bug Fix  
번호 매긴 항목들은 모두 이어지는 내용. 

## `PublicHome` 모바일 레이아웃 약간 변경 
기존 코드:
```tsx
<CardContent className="flex flex-col items-start justify-center gap-5 md:flex-row">
```
`items-center` 였다가 md 이상에서 텍스트가 길 경우 이미지 상하에 여백 생기는 것을 고치기 위해 `items-start` 로 변경했었다. 

그런데 모바일 화면에서는 `items-start` 하면 이미지가 작을 경우 왼쪽에 치우친다는 걸 까먹었다. 

수정:
```tsx
<CardContent className="flex flex-col items-center justify-center gap-5 md:flex-row md:items-start">
```



## 1. 모바일에서 내비게이션 바 반응형 안 되는 문제
resolves #43 

부트스트랩 -> TailwindCSS 로 바꾸면서 Tabs 컴포넌트의 내비게이션 부분에 반응형 적용이 안 되어 있었다는 걸 잊고 있었다. (교훈: 모바일 우선 작업 제발)
폰에서 확인해보니 내비게이션 바 가로로 잘리고 있었다. `flex-col` 은 짧은 메뉴 여러개다 보니 안 어울릴 것 같아서, 가로 길이 넘치면 줄 넘어가는 걸로 결정했다. 

shadcn에서 받은 Tabs 컴포넌트에서 
```typescript
const TabsList = React.forwardRef<
(중략)
    className={cn(
      "inline-flex h-9 
```

`inline-flex h-9` 지우고 `flex flex-wrap gap-1` 추가.
- `inline-flex` : 한 줄로만 되게 만드는 거
- `h-9` : 고정 높이 지워서 두 줄 이상 될 때 높이 자동 조절되도록 
그리고 메뉴 좀 큰 게 더 예쁜 것 같아서 하는 김에 `min-h-11` 도 추가. 

## 2. `Tabs` 너비 조절
1번 해결했더니 새롭게 등장한 문제: TabsList가 TabsContent 내부의 Card보다 약간 왼쪽으로 튀어나왔다. 
이걸 해결하려고 뜯어보다 보니 Public과 Admin 페이지가 원칙상 레이아웃이 똑같아야 하는데, `AdminTabs`와 `PublicContent`에서 각자 레이아웃을 조절하고 있었다는 걸 발견했다. 
통합하기 위해 그냥 Tabs 공통 컴포넌트에 margin과 width를 주기로 했다. 

```tsx
const Tabs = React.forwardRef<
  React.ElementRef<typeof TabsPrimitive.Root>,
  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
>(({ className, ...props }, ref) => (
  <TabsPrimitive.Root
    ref={ref}
    className={cn("mx-2 md:mx-8 lg:mx-auto lg:max-w-[1024px]", className)}
    {...props}
  />
));
Tabs.displayName = TabsPrimitive.Root.displayName;
```

`const Tabs = TabsPrimitive.Root;` 로 단순 alias 할당되어있던 Tabs를 `forwardRef` 로 래핑하여 TailwindCSS 유틸리티 클래스 추가. 

기존에 PublicContent 등에 산발적으로 있던 `<Card className="mx-2 md:mx-8 lg:w-[1024px]">` 와 같은 클래스는 모두 삭제. 

### 아 맞다 로그인 
로그인도 탭을 쓰는데 여긴 같은 너비가 아니라는 걸 깜빡했다. 
하지만 그냥 Public과 Admin이 공동으로 사용하는 너비를 Tabs에 주고, 로그인 탭에만 예외 처리를 하는 게 낫겠다고 판단했다. 

수정된 코드: 
```tsx
<div className="mx-auto flex w-full max-w-lg flex-col gap-4 p-2 md:max-w-xl">
	<Tabs defaultValue="login" className="mx-0 w-full max-w-none md:mx-0">
```

## 3. lg 미만 뷰포트에서 Card 사이즈 문제 
2번에서 Tabs에 `"mx-2 md:mx-8 lg:mx-auto lg:max-w-[1024px]"` 를 추가했으나, 
lg 이상의 화면에서는 1024px 고정된 너비로 잘 나왔지만 lg(1024px) 미만 뷰포트에서 의도대로 너비가 동작하지 않았다. 

의도: `mx-2 md:mx-8` 여백만 남기고 Card 컴포넌트가 100% width로 채우기. 반응형. 
실제: 내부 텍스트 양에 따라 너비가 조정됨. 따라서 탭을 바꿀 때마다 카드의 너비가 달라지는 현상(shrink-to-fit) 발생. 

Admin에서는 너비가 꽉 채워지는데 Public에서만 문제가 발생해서 더 포인트를 찾기 어려웠다. 처음에는 둘 간 차이에 해답이 있을 거라고 생각해서 대조에 집중했으나 나중에 알고 보니 그냥 Admin 안에는 ReactQuill 에디터가 들어가 있어서 `w-full`이 가능했던 것뿐이었다. 

### 3-1. `PublicContainer` 에 `w-full` 주기

컴포넌트 구조가 대충 이런 식인데 
```
1 <PublicContainer>
2 	<PublicTabs> = <Tabs>
3		<PublicContents> = <Card>
4			<CardContent>
5				<div dangerouslySetInnerHTML={{
```

`w-full` 을 **부모 컴포넌트에서 줬어야 했는데** 자식 컴포넌트에서 줘야 한다고 착각했다.
아무래도 Admin 쪽에서 ReactQuill 에디터로 인해 너비가 최대로 늘어날 수 있었다는 점을 파악한 다음이라 자식이 넓어져야 한다고 생각한 듯하다. 

`min-w-full`, `max-w-full`, `w-full` 등 width 관련된 클래스들을 `PublicTabs` 이하의 컴포넌트들에서만 여러가지 조합으로 넣었다 빼기를 반복했다. `prose`도 width에 관여한다길래 `prose max-w-none dark:prose-invert prose-headings:!text-inherit prose-p:!text-inherit` 등의 클래스들도 마찬가지로 넣었다 뺐다 며칠간 삽질을 했다. Tailwind 클래스가 잘 안 먹히나 싶어서 인라인 스타일도 시도해봤지만 마찬가지였다. 
`w-full`만을 위한 `FullWidth`라는 컴포넌트를 만들어서 역시 `PublicTabs` 이하에서 여기저기 끼워넣어 봤지만 소용없었다. 

원래 `PublicContainer`는 CSS에 전혀 관여하지 않고 데이터 페칭 상태에 따라서 화면에 어떤 페이지를 띄워줄 것인지 결정하는 컴포넌트였기 때문에 거기까지 올라갈 생각을 미처 못했다. 여기까지 올라와서 `w-full`로 자식들을 제어해 줘야 하는 거였다. 

수정한 코드: `PublicContainer.tsx`
```tsx
<div className="flex w-full justify-center px-4">
	<div className="w-full max-w-[1024px]">
```

### 3-2. 또 다른 방법: `display:table` 활용 
사실 이 방법을 먼저 알게 되었다. 

```tsx
export default function PublicContents({ userid, tid }: Props) {

    <Card className="table w-full table-fixed lg:w-[1024px]">
      <CardContent className="table-cell">
        {content && (
```

- `display: table`: 요소를 테이블처럼 동작하게 만든다. 무슨 뜻이냐면, 해당 요소가 `display: block`처럼 쌓이는 대신 테이블처럼 레이아웃을 구성하며, 자식 요소 중 `display: table-row`, `display: table-cell` 등을 가진 요소들이 실제 테이블 구조처럼 정렬된다. 즉, 테이블의 레이아웃 규칙을 따르게 된다.
- `table-layout: fixed`: 브라우저의 "최적 너비 계산"을 무시하고 테이블의 너비를 내용과 상관없이 고정.
- `display: table-cell`: 자식 요소가 테이블 셀처럼 동작. 부모의 전체 너비를 차지.

그리고 Tabs에서 `"w-full mx-2 md:mx-8 lg:mx-auto lg:max-w-[1024px]"` 를 줘서
이렇게 지정된 너비를 강제로 유지하게 만들었다. 

#### 채택하지 않은 이유
table layout보다는 부모 컴포넌트에서 w-full 주는 것이 더 의도를 명확히 반영하기 때문에 3-1 방법을 선택했다. 

# Others
- `InitPage`에서 `UsageGuide` 컴포넌트 분리: 아래 데모 계정 설명 부분. `InitPage` 여전히 파일 너무 길어서 나중에 차차 컴포넌트 분리하고 싶음. 
- 불필요한 Tailwind Class 삭제. (ex: 안 먹히고 있던 `w-full`, `p-0` 등)
- 오타 수정. 
