### PR TITLE
feat: Public 페이지에서 SSR 늘리기

### DIFF
--- a/src/app/[locale]/[userid]/admin/loading.tsx
+++ b/src/app/[locale]/[userid]/admin/loading.tsx
@@ -1,0 +1,5 @@
+import LoadingPage from "@/app/components/LoadingPage";
+
+export default function Loading() {
+  return <LoadingPage />;
+}

--- a/src/app/[locale]/[userid]/loading.tsx
+++ b/src/app/[locale]/[userid]/loading.tsx
@@ -1,0 +1,5 @@
+import LoadingPage from "@/app/components/LoadingPage";
+
+export default function Loading() {
+  return <LoadingPage />;
+}

--- a/src/app/[locale]/[userid]/page.tsx
+++ b/src/app/[locale]/[userid]/page.tsx
@@ -1,5 +1,8 @@
+import { Suspense } from "react";
+
 import Footer from "@/app/components/common/Footer";
 import Header from "@/app/components/common/Header";
+import LoadingPage from "@/app/components/LoadingPage";
 import PublicContainer from "@/app/components/public/PublicContainer";
 
 interface Props {
@@ -13,7 +16,9 @@ export default function Page({ params }: Props) {
   return (
     <div className="flex flex-col items-center">
       <Header params={params} />
-      <PublicContainer userid={params.userid} />
+      <Suspense fallback={<LoadingPage />}>
+        <PublicContainer userid={params.userid} />
+      </Suspense>
       <Footer />
     </div>
   );

--- a/src/app/components/NoUserPage.tsx
+++ b/src/app/components/NoUserPage.tsx
@@ -1,8 +1,7 @@
-"use client";
+import { getTranslations } from "next-intl/server";
 
-import { useTranslations } from "next-intl";
+export default async function NoUserPage() {
+  const t = await getTranslations("message");
 
-export default function NoUserPage() {
-  const t = useTranslations("message");
-  return <h2 className="text-center">{t("noUser")}</h2>;
+  return <h2 className="text-center text-2xl font-medium">{t("noUser")}</h2>;
 }

--- a/src/app/components/public/PublicContainer.tsx
+++ b/src/app/components/public/PublicContainer.tsx
@@ -1,26 +1,37 @@
-"use client";
+import { isAxiosError } from "axios";
 
 import Title from "@/app/components/common/Title";
-import LoadingPage from "@/app/components/LoadingPage";
 import NoUserPage from "@/app/components/NoUserPage";
 import PublicTabs from "@/app/components/public/PublicTabs";
-import { useUser } from "@/hooks/useUser";
+import { User } from "@/models/user.model";
+import { get } from "@/util/http";
 
-export default function PublicContainer({ userid }: { userid: string }) {
-  const { user, isUserLoading, isUserError } = useUser(userid);
+export default async function PublicContainer({ userid }: { userid: string }) {
+  const user = await getUser(userid);
 
   return (
     <div className="flex w-full justify-center px-4">
       <div className="w-full max-w-[1024px]">
         <Title title={user?.username || userid} />
-        {isUserLoading ? (
-          <LoadingPage />
-        ) : isUserError || !user ? (
-          <NoUserPage />
-        ) : (
-          <PublicTabs userid={userid} />
-        )}
+        {!user ? <NoUserPage /> : <PublicTabs userid={userid} />}
       </div>
     </div>
   );
+}
+
+async function getUser(userid: string): Promise<User | null> {
+  try {
+    const response = await get<User>(`/users/user?userid=${userid}`);
+    if (!response) {
+      return null;
+    }
+    return response;
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 404) {
+      console.warn("사용자 없음 (404)");
+      return null;
+    }
+    console.error("사용자 정보 가져오기 실패:", error);
+    return null;
+  }
 }

--- a/src/app/components/public/PublicFile.tsx
+++ b/src/app/components/public/PublicFile.tsx
@@ -42,10 +42,14 @@ export default function PublicFile({ pdf }: Props) {
     <Card>
       <CardContent className="flex flex-col gap-5">
         {pdf ? (
-          <div className="flex items-center gap-3">
+          <div className="flex flex-col items-center gap-3 md:flex-row">
             <Button onClick={openPDF}>{tPdf("openBtn")}</Button>
 
-            {!isMobile && (
+            {isMobile ? (
+              <p className="text-sm text-gray-600">
+                {tPdf("mobileNotSupported")}
+              </p>
+            ) : (
               <Button variant="secondary" onClick={handlePreview}>
                 {showPreview ? tPdf("closePreview") : tPdf("openPreview")}
               </Button>
@@ -61,7 +65,7 @@ export default function PublicFile({ pdf }: Props) {
             <iframe
               src={pdf}
               onLoad={() => setIsLoading(false)}
-              className="h-[600px] w-full"
+              className="h-[100vh] w-full"
               title={tPdf("preview")}
             />
           </div>

--- a/src/app/components/public/PublicFile.tsx
+++ b/src/app/components/public/PublicFile.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState, useEffect } from "react";
+
+import { Button } from "@/app/components/common/Button";
+import { Card, CardContent } from "@/app/components/common/Card";
+
+import { LoadingIcon } from "../common/LoadingIcon";
+
+interface Props {
+  pdf?: string;
+}
+
+export default function PublicFile({ pdf }: Props) {
+  const tPdf = useTranslations("file");
+
+  const [isMobile, setIsMobile] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  const openPDF = () => {
+    window.open(pdf, "_blank");
+  };
+
+  const handlePreview = () => {
+    setShowPreview(!showPreview);
+  };
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-5">
+        {pdf ? (
+          <div className="flex items-center gap-3">
+            <Button onClick={openPDF}>{tPdf("openBtn")}</Button>
+
+            {!isMobile && (
+              <Button variant="secondary" onClick={handlePreview}>
+                {showPreview ? tPdf("closePreview") : tPdf("openPreview")}
+              </Button>
+            )}
+          </div>
+        ) : (
+          <p>{tPdf("noFile")}</p>
+        )}
+
+        {!isMobile && showPreview && pdf && (
+          <div className="w-full rounded border">
+            {isLoading && <LoadingIcon />}
+            <iframe
+              src={pdf}
+              onLoad={() => setIsLoading(false)}
+              className="h-[600px] w-full"
+              title={tPdf("preview")}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -8,6 +8,7 @@
   },
   "message": {
     "noUser": "No Such User",
+    "noPdf": "No PDF file",
     "confirmLogout": "Are you sure you want to log out?",
     "saveSuccess": "Saved successfully.",
     "saveFail": "An error occurred while saving. Please try again.",
@@ -70,7 +71,6 @@
     "pdfAttach": "Attach PDF",
     "pdfOpen": "Open current PDF",
     "pdfPending": "Uploading PDF. Please wait...",
-    "noPdf": "No PDF file",
     "profileImgAttach": "Attach Profile Image",
     "imgPending": "Uploading image. Please wait...",
     "tabManager": "Manage Tabs",
@@ -127,5 +127,14 @@
     "reservedWords": "Words like 'admin', 'user' cannot be used.",
     "invalidCharacters": "Only lowercase letters, numbers, hyphens (-), and underscores (_) are allowed.",
     "lengthError": "ID must be between 3 and 20 characters long."
+  },
+  "file": {
+    "file": "File",
+    "openBtn": "Open File",
+    "noFile": "No file has been uploaded.",
+    "mobileNotSupported": "PDF preview is not supported on mobile.",
+    "openPreview": "Open Preview",
+    "closePreview": "Close Preview",
+    "preview": "Preview"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -70,7 +70,6 @@
     "pdfAttach": "PDF 첨부",
     "pdfOpen": "현재 PDF 보기",
     "pdfPending": "파일 업로드 중입니다. 잠시만 기다려 주세요.",
-    "noPdf": "PDF 파일이 없습니다.",
     "profileImgAttach": "프로필 사진 첨부",
     "imgPending": "이미지 업로드 중입니다. 잠시만 기다려 주세요.",
     "tabManager": "탭 관리",
@@ -127,5 +126,14 @@
     "reservedWords": "admin, user 등의 단어는 사용할 수 없습니다.",
     "invalidCharacters": "영어 소문자, 숫자, 하이픈(-), 언더스코어(_)만 사용할 수 있습니다.",
     "lengthError": "아이디는 3자 이상 20자 이하로 입력해야 합니다."
+  },
+  "file": {
+    "file": "파일",
+    "openBtn": "파일 열기",
+    "noFile": "업로드된 파일이 없습니다.",
+    "mobileNotSupported": "모바일에서는 PDF 미리보기가 지원되지 않습니다.",
+    "openPreview": "미리보기 열기",
+    "closePreview": "미리보기 닫기",
+    "preview": "미리보기"
   }
 }


### PR DESCRIPTION
# Features

## Public 페이지에서 SSR 늘리기 
getUser, getHomeData, getTabs를 서버 컴포넌트에서 데이터를 받아오게 했다. 
퍼블릭 페이지는 특히나 수정 없이 정적으로 보기만 하는 페이지라 쉬웠다. 진작 이렇게 할 걸. 

NoUserPage도 굳이 클라이언트일 필요 없어서 서버 컴포넌트로 바꿨다. 

PublicContainer에서 훅 대신 서버에서 렌더링하면서 isLoading 상태가 빠져서 대신 그 위에서 Suspense 사용했고 
여기저기에 loading.tsx도 추가했다. 

## 파일 개편
### openPDF 버튼에서 탭으로 
기존에는 PDF 버튼을 누르면 pdf가 열리거나 파일이 없습니다 alert가 떴다. 
PublicTabs를 서버 컴포넌트로 만드려다 보니 alert를 여기에 넣을 수가 없어서 고민하다가, 저번에 실사용자가 PDF 파일 버튼 눈앞에 있는데도 못 찾고 있었던 게 떠올랐다. 그리고 pdf 말고 워드나 한글 등의 문서 파일은 못 넣느냐는 질문도. 그래서 기존 방식이 별로 UX가 좋지 않은 것 같다고 판단했다. 

버튼 위치는 TabsTrigger 맨 끝으로 유지하되 확장을 고려하여 "File" / "파일" 로 변경하였다. 한글로 파일이라고 써 있으면 더 잘 보이지 않을까 싶어서. 
그리고 AdminPDF와 마찬가지로 누르면 TabsContents로 카드 body 나오게 했다. `PublicFile` 컴포넌트를 새로 만들었다. 

### PDF 미리보기 추가 
`iframe`을 새로 알게 됐다. 이슈 등록해놓고 나중에 하려고 했는데, 너무 간단하길래 금방 적용해 봤다. 
다만 모바일에서는 안된다고 하길래 모바일이 아닐 때만 미리보기 열기 토글을 보여줬다. 

나중에 워드, 한글 등으로 확장하면 미리보기도 복잡해질 수 있다. 워드는 그래도 할 수는 있는데 한글은 거의 불가능할 듯. 파일 확장자에 따라 미리보기 지원 여부 나눠야 한다. 


resolves #50 
사실 해결했다고 말하긴 애매하긴 한데 퍼블릭 했으면 어느 정도 다 한 게 아닐까. admin 페이지가 뭐 ssr이 중요하겠어 초기 속도도 많이 느리지 않으면 됐고 
