### PR TITLE
chore: node 버전 업그레이드 및 gcs 타입 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@types/bcrypt": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/multer": "^1.4.7",
-        "@types/node": "^18.19.76",
+        "@types/node": "^22.0.0",
         "@types/nodemailer": "^6.4.9",
         "autoprefixer": "^10.4.20",
         "eslint": "8.57.1",
@@ -2055,12 +2055,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.76",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
-      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+      "version": "22.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
+      "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -9084,9 +9084,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -10832,11 +10832,11 @@
       }
     },
     "@types/node": {
-      "version": "18.19.76",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
-      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+      "version": "22.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
+      "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/nodemailer": {
@@ -15467,9 +15467,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/bcrypt": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/multer": "^1.4.7",
-    "@types/node": "^18.19.76",
+    "@types/node": "^22.0.0",
     "@types/nodemailer": "^6.4.9",
     "autoprefixer": "^10.4.20",
     "eslint": "8.57.1",


### PR DESCRIPTION
# 변경사항
## Node 버전 18에서 22로 업그레이드 
그래야 했던 이유는 resolves #69 참고.

## Buffer/Uint8Array 타입 충돌 해결
### 과거에 썼던 방법 
PR #36 에서 

#### 문제 상황
Next.js 14 + TypeScript 5.5 + `@types/node@20` 환경에서 GCS 연동 시 타입 에러 발생.
`Buffer.concat()` 호출 시,  `Argument of type 'Buffer[]' is not assignable to parameter of type 'readonly Uint8Array<ArrayBufferLike>[]'`

#### 당시 원인 분석 
##### 1. `@types/node@20`에서 Buffer와 Uint8Array 호환성 약화
Buffer는 Uint8Array를 상속받는 하위 클래스. 
- Next.js 기본 `moduleResolution: bundler`는 브라우저/서버 통합 환경을 위해 웹 표준 타입(Uint8Array)을 우선 적용하는 성질이 있음
- 그러나, GCS SDK는 Node.js 전용 라이브러리로, Node.js 고유 타입(Buffer)을 기대
- 특히 최신 `@types/node@20`에서부터 이 두 타입 간 호환성 관련 정의가 변경되면서 node 18에선 없었던 타입 충돌 심화. 

##### 2. 서버 전용 라이브러리(GCS SDK)와 클라이언트 친화적 타입 시스템 간 충돌
- Next.js의 기본 `moduleResolution: bundler` 설정은 클라이언트 친화적으로 타입을 체크하기 위한 옵션.
- 그러나, 서버 전용 라이브러리(GCS SDK, Node.js Buffer 등)를 사용할 때는 `moduleResolution: node`가 더 적절.
- 이 프로젝트는 Next.js API Route에서 GCS를 호출하는 구조이므로, 실제 실행 환경은 Node.js이지만, 타입 체크는 `bundler` 기준으로 진행되면서 타입 충돌이 발생. 

#### 선택한 해결 방법과 근거 
- 해결: `@types/node`를 20.x에서 18.x로 다운그레이드함으로써 해결. 
- 근거 : 당시 Next.js 공식 런타임과 Vercel 기본 런타임 둘 다 Node 18 기준. 운영 환경과 타입 정의를 맞추는 것이 합리적으로 보임. 

### 과거 접근법에 대한 비판 및 상황 변화 
#### 비판
##### 문제 오해: 타입 시스템 이슈가 아니라 내 코드 문제였음 
`@types/node` 버전과 Next.js 설정 간 호환성 문제라고 판단했으나, 
사실은 그냥 내가 타입을 잘못 지정한 거였음. 

구 코드
```
export const downloadFile = async (filename: string): Promise<Buffer> => {
  const file = bucket.file(filename);

return new Promise((resolve, reject) => {
  const chunks: Buffer[] = [];  // ❌ 잘못된 타입 가정
  
  file.createReadStream()
    .on("data", (chunk) => chunks.push(chunk))  // chunk는 실제로 Uint8Array
    .on("end", () => resolve(Buffer.concat(chunks)));  // Buffer[] 기대하지만 Uint8Array[] 전달
});
```

downloadFile()이 `Promise<Buffer>` 타입을 반환해야 하기 때문에, chunk도 Buffer 배열이어야 한다고 오해한 것. 
그러나 실제로 `file.createReadStream()`을 통해 Node.js 스트림이 주는 데이터는 `Uint8Array` 타입. 

Node 18까지는 `chunks` 배열의 타입을 `Buffer[]`로 지정함으로써 이 배열에 push되는 `Uint8Array` 타입 데이터를 `Buffer`로 강제 타입 변환할 수 있었지만, Node 20부터 그게 막힌 것. 

##### 임시방편적 해결
향후 Node.js 버전 업그레이드 시 동일한 문제가 재발할 가능성 <- 바로 지금!
또한 최신 타입 정의의 장점(더 정확한 타입 체크)을 포기했다는 점도. 
#### 상황 변화 
#69 
Vercel에서 Node.js 18 지원 중단. 

### 해결
Node.js 스트림이 주는 데이터에 맞춰 `const chunks: Uint8Array[] = [];` 로 받고, 
`.on("end", () => {` 이 대목에서 `Uint8Array`를 `Buffer`로 수동 변환하는 코드를 추가했다. 

# 여담
근데 `downloadFile()` 함수 안 쓰이는 거 알고 있었냐. 
파일 다운로드 기능 없잖아... 
프사는 다운받을 이유가 없고, pdf는 열면 거기서 파일 저장 되니까 굳이 만들 필요 없었고. 
나중에 파일 첨부 기능이 확장되면 쓰려고 그냥 GCS 연결할 때 하는 김에 만들어뒀던 함수지. 
쓰지도 않는 함수가 나를 이렇게 괴롭히다니. 