### PR TITLE
텍스트 에디터에 이미지 첨부 기능 추가 

### DIFF
--- a/components.json
+++ b/components.json
@@ -11,10 +11,10 @@
     "prefix": ""
   },
   "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
+    "components": "@/app/components",
+    "utils": "@/util/classname",
+    "ui": "@/app/components/common",
+    "lib": "@/util",
     "hooks": "@/hooks"
   },
   "iconLibrary": "lucide"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "next-themes": "^0.4.4",
         "nodemailer": "^6.9.4",
         "pg": "^8.11.3",
+        "quill": "^2.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.3.0",
@@ -3434,6 +3435,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -3688,6 +3690,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
       "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
       "dependencies": {
         "is-arguments": "^1.1.1",
         "is-date-object": "^1.0.5",
@@ -4698,9 +4701,10 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4715,9 +4719,10 @@
       "license": "MIT"
     },
     "node_modules/fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -5555,12 +5560,13 @@
       }
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6249,11 +6255,30 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -6767,6 +6792,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -7528,30 +7554,39 @@
       "license": "MIT"
     },
     "node_modules/quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "clone": "^2.1.1",
-        "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
-        "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "engines": {
+        "npm": ">=8.2.3"
       }
     },
     "node_modules/quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
       "dependencies": {
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">= 12.0.0"
       }
+    },
+    "node_modules/quill/node_modules/parchment": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -7604,6 +7639,46 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+      "license": "MIT"
+    },
+    "node_modules/react-quill/node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/react-quill/node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/react-quill/node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/react-redux": {
@@ -12644,9 +12719,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "extend": {
       "version": "3.0.2",
@@ -12660,9 +12735,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -13239,12 +13314,12 @@
       }
     },
     "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       }
     },
     "is-array-buffer": {
@@ -13682,11 +13757,26 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.castarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -14434,26 +14524,31 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "requires": {
-        "clone": "^2.1.1",
-        "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
-        "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "dependencies": {
+        "parchment": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+          "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="
+        }
       }
     },
     "quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
       "requires": {
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
       }
     },
     "react": {
@@ -14493,6 +14588,41 @@
         "@types/quill": "^1.3.10",
         "lodash": "^4.17.4",
         "quill": "^1.3.7"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        },
+        "fast-diff": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+          "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+        },
+        "quill": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+          "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+          "requires": {
+            "clone": "^2.1.1",
+            "deep-equal": "^1.0.1",
+            "eventemitter3": "^2.0.3",
+            "extend": "^3.0.2",
+            "parchment": "^1.1.4",
+            "quill-delta": "^3.6.2"
+          }
+        },
+        "quill-delta": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+          "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+          "requires": {
+            "deep-equal": "^1.0.1",
+            "extend": "^3.0.2",
+            "fast-diff": "1.1.2"
+          }
+        }
       }
     },
     "react-redux": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "next-themes": "^0.4.4",
     "nodemailer": "^6.9.4",
     "pg": "^8.11.3",
+    "quill": "^2.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.3.0",

--- a/src/app/api/home/img/route.ts
+++ b/src/app/api/home/img/route.ts
@@ -26,7 +26,6 @@ export async function POST(req: Request) {
       "image/png",
       "image/gif",
       "image/webp",
-      "image/svg+xml",
       "image/bmp",
     ];
 
@@ -35,7 +34,7 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           error:
-            "잘못된 파일 형식입니다. JPG, PNG, GIF, WebP, SVG, BMP만 업로드 가능합니다.",
+            "잘못된 파일 형식입니다. JPG, PNG, GIF, WebP, BMP만 업로드 가능합니다.",
         },
         { status: 400 },
       );

--- a/src/app/api/tabs/img/route.ts
+++ b/src/app/api/tabs/img/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+
+import { query } from "@/util/database";
+import { uploadFile } from "@/util/gcs";
+
+export async function POST(request: Request) {
+  try {
+    // multipart/form-data 형식으로 넘어온 데이터를 받기
+    const formData = await request.formData();
+
+    // formData에서 파일과 userid 가져오기
+    const file = formData.get("file") as File | null;
+    const userId = formData.get("userid") as string | null;
+
+    if (!file || !userId) {
+      return NextResponse.json(
+        { error: "이미지 파일 혹은 userId가 누락되었습니다." },
+        { status: 400 },
+      );
+    }
+
+    // 허용할 이미지 MIME 타입 목록
+    const allowedTypes = [
+      "image/jpg",
+      "image/jpeg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+      "image/svg+xml",
+      "image/bmp",
+    ];
+
+    // 업로드된 파일이 허용된 이미지 형식인지 검사
+    if (!allowedTypes.includes(file.type)) {
+      return NextResponse.json(
+        {
+          error:
+            "잘못된 파일 형식입니다. JPG, PNG, GIF, WebP, SVG, BMP만 업로드 가능합니다.",
+        },
+        { status: 400 },
+      );
+    }
+
+    // 이미지 GCS에 업로드
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    const uniqueFilename = `${file.name}-${Date.now()}`;
+    const imageUrl = `https://storage.googleapis.com/easiest-cv/${uniqueFilename}`;
+
+    await uploadFile(uniqueFilename, buffer, "image");
+
+    // DB에 GCS 링크 저장????????????
+    await query("UPDATE tabs SET img = $1 WHERE userid = $2", [
+      imageUrl,
+      userId,
+    ]);
+
+    // 업로드 결과 반환
+    return NextResponse.json({ imageUrl }, { status: 200 });
+  } catch (error) {
+    console.error("이미지 업로드 실패:", error);
+    return NextResponse.json(
+      { error: "이미지 업로드 중 오류가 발생했습니다." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/tabs/img/route.ts
+++ b/src/app/api/tabs/img/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { ApiErrorResponse } from "@/models/api";
 import { uploadFile } from "@/util/gcs";
 
 export async function POST(request: Request) {
@@ -12,19 +13,21 @@ export async function POST(request: Request) {
     const userId = formData.get("userid") as string | null;
 
     if (!file || !userId) {
-      return NextResponse.json(
-        { error: "이미지 파일 혹은 userId가 누락되었습니다." },
-        { status: 400 },
-      );
+      const response: ApiErrorResponse = {
+        message: "이미지 파일 혹은 userId가 누락되었습니다.",
+        errorType: "VALIDATION_ERROR",
+      };
+      return NextResponse.json(response, { status: 400 });
     }
 
     // 파일 크기 검증 추가
     const maxSize = 20 * 1024 * 1024; // 20MB
     if (file.size > maxSize) {
-      return NextResponse.json(
-        { error: "파일 크기는 20MB를 초과할 수 없습니다." },
-        { status: 400 },
-      );
+      const response: ApiErrorResponse = {
+        message: "파일 크기는 20MB를 초과할 수 없습니다.",
+        errorType: "FILE_SIZE_ERROR",
+      };
+      return NextResponse.json(response, { status: 400 });
     }
 
     // 허용할 이미지 MIME 타입 목록
@@ -34,19 +37,17 @@ export async function POST(request: Request) {
       "image/png",
       "image/gif",
       "image/webp",
-      "image/svg+xml",
       "image/bmp",
     ];
 
     // 업로드된 파일이 허용된 이미지 형식인지 검사
     if (!allowedTypes.includes(file.type)) {
-      return NextResponse.json(
-        {
-          error:
-            "잘못된 파일 형식입니다. JPG, PNG, GIF, WebP, SVG, BMP만 업로드 가능합니다.",
-        },
-        { status: 400 },
-      );
+      const response: ApiErrorResponse = {
+        message:
+          "지원하지 않는 이미지 형식입니다. JPG, PNG, GIF, WebP, BMP만 업로드 가능합니다.",
+        errorType: "INVALID_IMAGE_TYPE",
+      };
+      return NextResponse.json(response, { status: 400 });
     }
 
     // 이미지 GCS에 업로드

--- a/src/app/components/admin/AdminEditor.tsx
+++ b/src/app/components/admin/AdminEditor.tsx
@@ -2,16 +2,17 @@ import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import React, { useEffect, useMemo, useState, useRef } from "react";
 
+import ImageUploader from "@/app/components/admin/ImageUploader";
 import { Button } from "@/app/components/common/Button";
 import { useHome } from "@/hooks/useHome";
 import { useTabs } from "@/hooks/useTabs";
 import { Tab } from "@/models/tab.model";
 import { cn } from "@/util/classname";
+import extractFileName from "@/util/extractFileName";
 import useDebounce from "@/util/useDebounce";
 
 const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
 import "react-quill/dist/quill.snow.css";
-import ImageUploader from "./ImageUploader";
 
 type SaveStatus = "saved" | "saving" | "unsaved" | "error";
 
@@ -125,6 +126,19 @@ export default function AdminEditor({ userid, tid }: Props) {
 
   const quillInstanceRef = useRef<QuillWrapper | null>(null);
 
+  const refreshImages = () => {
+    const quillInstance = quillInstanceRef.current?.quill;
+    if (quillInstance) {
+      const images = quillInstance.root.querySelectorAll("img");
+      images.forEach((img) => {
+        const src = img.src;
+        img.src = "";
+        img.src = src;
+        img.alt = extractFileName(src);
+      });
+    }
+  };
+
   const insertImage = (imageUrl: string) => {
     const quillInstance = quillInstanceRef.current?.quill;
 
@@ -140,6 +154,10 @@ export default function AdminEditor({ userid, tid }: Props) {
         quillInstance.insertEmbed(index, "image", imageUrl);
         // 5. 커서를 이미지 다음 위치로 이동
         quillInstance.setSelection(index + 1);
+
+        setTimeout(() => {
+          refreshImages();
+        }, 700); // 500까지 엑박이다가 700은 되네?
       } catch (error) {
         console.error("Error inserting image:", error);
       }

--- a/src/app/components/admin/AdminEditor.tsx
+++ b/src/app/components/admin/AdminEditor.tsx
@@ -31,6 +31,7 @@ interface Props {
 
 export default function AdminEditor({ userid, tid }: Props) {
   const tEditor = useTranslations("editor");
+  const tError = useTranslations("error");
 
   const { homeData, mutateUploadIntro, revertIntro } = useHome(userid);
   const { tabs, updateContents, revertContents } = useTabs(userid);
@@ -157,8 +158,9 @@ export default function AdminEditor({ userid, tid }: Props) {
 
         setTimeout(() => {
           refreshImages();
-        }, 700); // 500까지 엑박이다가 700은 되네?
+        }, 1000);
       } catch (error) {
+        alert(tError("imgInsertFail"));
         console.error("Error inserting image:", error);
       }
     } else {

--- a/src/app/components/admin/AdminEditor.tsx
+++ b/src/app/components/admin/AdminEditor.tsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/app/components/common/Button";
 import { useHome } from "@/hooks/useHome";
@@ -11,6 +11,7 @@ import useDebounce from "@/util/useDebounce";
 
 const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
 import "react-quill/dist/quill.snow.css";
+import ImageUploader from "./ImageUploader";
 
 type SaveStatus = "saved" | "saving" | "unsaved" | "error";
 
@@ -29,6 +30,8 @@ export default function AdminEditor({ userid, tid }: Props) {
     tabs.find((t) => t.tid === tid) || null,
   );
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
+
+  const [isImageUploaderOpen, setIsImageUploaderOpen] = useState(false);
 
   useEffect(() => {
     setCurrentTab(tabs.find((t) => t.tid === tid) || null);
@@ -112,6 +115,32 @@ export default function AdminEditor({ userid, tid }: Props) {
 
   const statusDisplay = getStatusDisplay();
 
+  const handleClickImage = () => {
+    setIsImageUploaderOpen(true);
+  };
+
+  const modules = useMemo(() => {
+    return {
+      toolbar: {
+        container: [
+          [{ header: [1, 2, 3, 4, 5, false] }],
+          ["bold", "italic", "underline", "strike", "blockquote"],
+          [
+            { list: "ordered" },
+            { list: "bullet" },
+            { indent: "-1" },
+            { indent: "+1" },
+          ],
+          ["image"],
+          [{ align: [] }, { color: [] }, { background: [] }],
+        ],
+        handlers: {
+          image: handleClickImage,
+        },
+      },
+    };
+  }, []);
+
   return (
     <div className="flex flex-1 flex-col gap-4">
       <div className="flex items-end justify-between gap-1">
@@ -140,25 +169,14 @@ export default function AdminEditor({ userid, tid }: Props) {
         value={value}
         onChange={handleValueChange}
       />
+      <ImageUploader
+        isOpen={isImageUploaderOpen}
+        onClose={() => setIsImageUploaderOpen(false)}
+      />
     </div>
   );
 }
 
-const modules = {
-  toolbar: [
-    [{ header: [1, 2, 3, 4, 5, false] }],
-    ["bold", "italic", "underline", "strike", "blockquote"],
-    [
-      { list: "ordered" },
-      { list: "bullet" },
-      { indent: "-1" },
-      { indent: "+1" },
-    ],
-    ["link"],
-    [{ align: [] }, { color: [] }, { background: [] }],
-    ["clean"],
-  ],
-};
 const formats = [
   "header",
   "bold",
@@ -168,9 +186,8 @@ const formats = [
   "list",
   "bullet",
   "indent",
-  "link",
+  "image",
   "align",
   "color",
   "background",
-  "clean",
 ];

--- a/src/app/components/admin/ImageUploader.tsx
+++ b/src/app/components/admin/ImageUploader.tsx
@@ -1,0 +1,58 @@
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/app/components/common/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/app/components/common/Dialog";
+import { Input } from "@/app/components/common/Input";
+
+interface ImageUploaderProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ImageUploader({ isOpen, onClose }: ImageUploaderProps) {
+  const tButton = useTranslations("button");
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || e.target.files.length === 0) return;
+    const file = e.target.files[0];
+    alert(`Selected file: ${file.name}`);
+    console.log("Selected file:", file);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Image Uploader</DialogTitle>
+        </DialogHeader>
+
+        <Input
+          id="imageUpload"
+          type="file"
+          accept="image/*"
+          onChange={handleImageUpload}
+        />
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>
+            {tButton("cancel")}
+          </Button>
+
+          {/* {changePWStatus === "pending" ? (
+                <Button disabled>
+                  <Loader2Icon className="animate-spin" />
+                  {tButton("pending")}
+                </Button>
+              ) : ( */}
+          <Button type="submit">{tButton("confirm")}</Button>
+          {/* )} */}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/components/admin/ImageUploader.tsx
+++ b/src/app/components/admin/ImageUploader.tsx
@@ -28,6 +28,8 @@ export default function ImageUploader({
   onImageInsert,
 }: ImageUploaderProps) {
   const tButton = useTranslations("button");
+  const tEditor = useTranslations("editor");
+  const tError = useTranslations("error");
 
   const { uploadImgToGCS } = useTabs(userid);
 
@@ -50,7 +52,12 @@ export default function ImageUploader({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!previewImage) return;
+
+    if (!previewImage) {
+      alert(tError("noImgToUpload"));
+      return;
+    }
+
     const formData = new FormData();
     const fileInput = document.getElementById(
       "imageUpload",
@@ -64,7 +71,7 @@ export default function ImageUploader({
       const result = await uploadImgToGCS(formData);
       onImageInsert(result.imageUrl);
     } catch (error) {
-      alert("이미지 업로드에 실패했습니다.");
+      // alert는 위 로직 안에 다 있음
       console.error("Error uploading image:", error);
     } finally {
       onClose();
@@ -75,7 +82,7 @@ export default function ImageUploader({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="mx-auto max-w-[calc(100vw-2rem)] rounded-lg md:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Image Uploader</DialogTitle>
+          <DialogTitle>{tEditor("imgUploader")}</DialogTitle>
         </DialogHeader>
 
         <div className="flex flex-col items-center space-y-4">

--- a/src/app/components/admin/ImageUploader.tsx
+++ b/src/app/components/admin/ImageUploader.tsx
@@ -1,4 +1,6 @@
+import Image from "next/image";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 
 import { Button } from "@/app/components/common/Button";
 import {
@@ -17,26 +19,50 @@ interface ImageUploaderProps {
 
 export default function ImageUploader({ isOpen, onClose }: ImageUploaderProps) {
   const tButton = useTranslations("button");
-  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+
+  const [previewImage, setPreviewImage] = useState<string | null>(null);
+
+  const handleImageInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) return;
     const file = e.target.files[0];
-    alert(`Selected file: ${file.name}`);
-    console.log("Selected file:", file);
+
+    const fileUrl = URL.createObjectURL(file);
+    setPreviewImage(fileUrl);
+
+    // 메모리 누수 방지를 위해 기존 URL 해제 (옵션)
+    return () => {
+      if (previewImage) {
+        URL.revokeObjectURL(previewImage);
+      }
+    };
   };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
+      <DialogContent className="mx-auto max-w-[calc(100vw-2rem)] rounded-lg md:max-w-lg">
         <DialogHeader>
           <DialogTitle>Image Uploader</DialogTitle>
         </DialogHeader>
 
-        <Input
-          id="imageUpload"
-          type="file"
-          accept="image/*"
-          onChange={handleImageUpload}
-        />
+        <div className="flex flex-col items-center space-y-4">
+          <Input
+            id="imageUpload"
+            type="file"
+            accept="image/*"
+            onChange={handleImageInput}
+          />
+
+          {previewImage && (
+            <Image
+              src={previewImage}
+              alt="preview image"
+              width={0}
+              height={0}
+              className="max-h-64 w-auto rounded-lg object-contain"
+              unoptimized
+            />
+          )}
+        </div>
 
         <DialogFooter>
           <Button variant="secondary" onClick={onClose}>

--- a/src/app/components/admin/ImageUploader.tsx
+++ b/src/app/components/admin/ImageUploader.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import { Button } from "@/app/components/common/Button";
 import {
@@ -35,19 +35,21 @@ export default function ImageUploader({
 
   const [previewImage, setPreviewImage] = useState<string | null>(null);
 
+  useEffect(() => {
+    // cleanup function: previewImage가 변경되기 전 URL 정리
+    return () => {
+      if (previewImage) {
+        URL.revokeObjectURL(previewImage);
+      }
+    };
+  }, [previewImage]);
+
   const handleImageInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) return;
     const file = e.target.files[0];
 
     const fileUrl = URL.createObjectURL(file);
     setPreviewImage(fileUrl);
-
-    // 메모리 누수 방지를 위해 기존 URL 해제 (옵션)
-    return () => {
-      if (previewImage) {
-        URL.revokeObjectURL(previewImage);
-      }
-    };
   };
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/app/components/admin/UserInfoEditor.tsx
+++ b/src/app/components/admin/UserInfoEditor.tsx
@@ -11,9 +11,8 @@ import {
   DialogTitle,
 } from "@/app/components/common/Dialog";
 import { Input } from "@/app/components/common/Input";
+import { LoadingIcon } from "@/app/components/common/LoadingIcon";
 import { useUser } from "@/hooks/useUser";
-
-import { LoadingIcon } from "../common/LoadingIcon";
 
 interface UserInfoEditorProps {
   userid: string;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,6 +20,7 @@ export default function useAuth() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const tMessage = useTranslations("message");
+  const tError = useTranslations("error");
   const tInitPage = useTranslations("initpage");
 
   const { data: me, isLoading } = useQuery({
@@ -47,7 +48,7 @@ export default function useAuth() {
 
       // 네트워크 에러 (서버에 연결 불가)
       if (!error.response) {
-        alert(tMessage("networkError"));
+        alert(tError("networkError"));
         console.error("네트워크 에러:", error.message);
         return;
       }
@@ -55,11 +56,11 @@ export default function useAuth() {
       // 서버에서 응답은 왔지만 에러인 경우
       const { status, data } = error.response;
       const errorType = data.errorType;
-      const message = data.message || tMessage("unknownError");
+      const message = data.message || tError("unknownError");
 
       switch (errorType) {
         case "MISSING_FIELDS":
-          alert(tMessage("missingFields"));
+          alert(tError("missingFields"));
           break;
         case "USER_NOT_FOUND":
           alert(tMessage("noUser"));
@@ -68,7 +69,7 @@ export default function useAuth() {
           alert(tMessage("passwordMismatch"));
           break;
         case "SERVER_ERROR":
-          alert(tMessage("serverError"));
+          alert(tError("serverError"));
           break;
         default:
           alert(tInitPage("loginFail"));
@@ -104,17 +105,17 @@ export default function useAuth() {
 
       // 네트워크 에러 (서버에 연결 불가)
       if (!error.response) {
-        alert(tMessage("networkError"));
+        alert(tError("networkError"));
         console.error("네트워크 에러:", error.message);
         return;
       }
 
       // 서버에서 응답은 왔지만 에러인 경우
       const { status, data } = error.response;
-      const message = data.message || tMessage("unknownError");
+      const message = data.message || tError("unknownError");
 
       if (status === 500) {
-        alert(tMessage("networkError"));
+        alert(tError("networkError"));
       } else {
         alert(message);
       }
@@ -136,7 +137,7 @@ export default function useAuth() {
 
       // 네트워크 에러 (서버에 연결 불가)
       if (!error.response) {
-        alert(tMessage("networkError"));
+        alert(tError("networkError"));
         console.error("네트워크 에러:", error.message);
         return;
       }
@@ -147,13 +148,13 @@ export default function useAuth() {
 
       switch (status) {
         case 400:
-          alert(tMessage("missingFields"));
+          alert(tError("missingFields"));
           break;
         case 409:
           alert(tInitPage("duplicateId"));
           break;
         case 500:
-          alert(tMessage("serverError"));
+          alert(tError("serverError"));
           break;
         default:
           alert(message);

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -10,6 +10,7 @@ export const useHome = (userid: string) => {
   const queryClient = useQueryClient();
   const tMessage = useTranslations("message");
   const tEditor = useTranslations("editor");
+  const tError = useTranslations("error");
 
   // 1) 홈 데이터 조회
   const {
@@ -37,7 +38,7 @@ export const useHome = (userid: string) => {
       refetch();
     },
     onError: (err) => {
-      alert(tMessage("saveFail"));
+      alert(tError("saveFail"));
       console.error("PDF 업로드 에러:", err);
     },
   });
@@ -55,7 +56,7 @@ export const useHome = (userid: string) => {
       refetch();
     },
     onError: (err) => {
-      alert(tMessage("imgUploadFail"));
+      alert(tError("imgUploadFail"));
       console.error("이미지 업로드 에러:", err);
     },
   });
@@ -75,7 +76,7 @@ export const useHome = (userid: string) => {
       queryClient.refetchQueries({ queryKey: queryKeys.home({ userid }) });
     },
     onError: (error) => {
-      alert(tMessage("saveFail"));
+      alert(tError("saveFail"));
       console.error("intro 업로드 에러:", error);
     },
   });
@@ -92,7 +93,7 @@ export const useHome = (userid: string) => {
   const revertIntro = (): null | void => {
     try {
       if (!backUpIntroRef.current || backUpIntroRef.current.length === 0) {
-        alert(tEditor("revertNoBackup"));
+        alert(tError("revertNoBackup"));
         return null;
       }
 

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -50,12 +50,12 @@ export const useHome = (userid: string) => {
   } = useMutation({
     mutationFn: uploadImg,
     onSuccess: () => {
-      alert(tMessage("saveSuccess"));
+      alert(tMessage("imgUploadSuccess"));
       queryClient.refetchQueries({ queryKey: queryKeys.home({ userid }) });
       refetch();
     },
     onError: (err) => {
-      alert(tMessage("saveFail"));
+      alert(tMessage("imgUploadFail"));
       console.error("이미지 업로드 에러:", err);
     },
   });

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -166,7 +166,7 @@ export const useTabs = (userid: string) => {
   const revertContents = (tid: number): null | void => {
     try {
       if (!backUpTabsRef.current) {
-        alert(tEditor("revertNoBackup"));
+        alert(tError("revertNoBackup"));
         return null;
       }
 
@@ -177,7 +177,7 @@ export const useTabs = (userid: string) => {
         backupTab.contents === undefined ||
         backupTab.contents === null
       ) {
-        alert(tEditor("revertNoBackupForTab"));
+        alert(tError("revertNoBackupForTab"));
         console.error(`탭 ID ${tid}에 대한 백업 데이터를 찾을 수 없습니다.`);
         return null;
       }
@@ -191,7 +191,7 @@ export const useTabs = (userid: string) => {
         contents: backupTab.contents,
       });
     } catch (error) {
-      alert(tEditor("revertError"));
+      alert(tError("revertError"));
       console.error("revertContents", error);
     }
   };

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -130,7 +130,6 @@ export const useTabs = (userid: string) => {
   };
 
   // 내용 되돌리기
-
   const backUpTabsRef = useRef<Tab[] | null>(null);
   useEffect(() => {
     if (serverTabs.length > 0 && !backUpTabsRef.current) {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -10,6 +10,7 @@ import { get, patch, put } from "@/util/http";
 export const useUser = (userid: string) => {
   const queryClient = useQueryClient();
   const tMessage = useTranslations("message");
+  const tError = useTranslations("error");
   const tChangePW = useTranslations("changePassword");
 
   const {
@@ -45,8 +46,8 @@ export const useUser = (userid: string) => {
       if (!error.response) {
         alert(
           error.code === "ECONNABORTED"
-            ? tMessage("timeout")
-            : tMessage("networkError"),
+            ? tError("timeout")
+            : tError("networkError"),
         );
         return;
       }
@@ -58,10 +59,10 @@ export const useUser = (userid: string) => {
       // 주요 케이스만 처리
       if (status === 400 && errorData?.errorType === "VALIDATION_ERROR") {
         console.log(errorData.message);
-        alert(tMessage("missingFields"));
+        alert(tError("missingFields"));
       } else {
         console.log(status, errorData.message);
-        alert(tMessage("saveFail"));
+        alert(tError("saveFail"));
       }
     },
   });
@@ -77,7 +78,7 @@ export const useUser = (userid: string) => {
       // 네트워크 에러
       if (!error.response || error.request?.status === 0) {
         console.log("네트워크 에러");
-        alert(tMessage("networkError"));
+        alert(tError("networkError"));
         return;
       }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -11,26 +11,26 @@
     "noPdf": "No PDF file",
     "confirmLogout": "Are you sure you want to log out?",
     "saveSuccess": "Saved successfully.",
-    "saveFail": "An error occurred while saving. Please try again.",
     "loading": "Loading...",
     "cancelConfirm": "Your changes will not be saved. Are you sure you want to cancel?",
     "passwordMismatch": "Passwords do not match.",
+    "imgUploadSuccess": "Image upload completed successfully."
+  },
+  "error": {
+    "saveFail": "An error occurred while saving. Please try again.",
+    "timeout": "Request timed out. Please try again.",
     "networkError": "Please check your network connection.",
     "unknownError": "An unknown error occurred. Please try again.",
     "serverError": "Server error occurred. Please contact the administrator.",
     "missingFields": "Please fill in all fields correctly.",
-    "timeout": "Request timed out. Please try again.",
-    "imgUploadSuccess": "Image upload completed successfully.",
-    "imgUploadFail": "An error occurred while uploading the image. Please try again."
-  },
-  "error": {
-    "timeout": "Request timed out. Please try again.",
-    "networkError": "Please check your network connection.",
     "fileSizeError": "The maximum file size allowed is 20MB.",
     "noImgToUpload": "Select an image file to insert.",
     "imgInsertFail": "Failed to insert image. Please try again.",
     "imgUploadFail": "An error occurred while uploading the image. Please try again.",
-    "invalidImageType": "Unsupported image format. Only JPG, PNG, BMP, WebP, and GIF are allowed."
+    "invalidImageType": "Unsupported image format. Only JPG, PNG, BMP, WebP, and GIF are allowed.",
+    "revertError": "An error occurred while reverting. Please try again.",
+    "revertNoBackup": "No backup data available.",
+    "revertNoBackupForTab": "No backup data found for this tab."
   },
   "label": {
     "name": "Name",
@@ -103,9 +103,6 @@
     "autoSaveInfo": "Changes are saved automatically.",
     "revert": "Revert",
     "revertConfirm": "Do you want to revert to the previous version? All current inputs will be lost.",
-    "revertError": "An error occurred while reverting. Please try again.",
-    "revertNoBackup": "No backup data available.",
-    "revertNoBackupForTab": "No backup data found for this tab.",
     "imgUploader": "Image Uploader"
   },
   "editUserInfo": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -19,7 +19,18 @@
     "unknownError": "An unknown error occurred. Please try again.",
     "serverError": "Server error occurred. Please contact the administrator.",
     "missingFields": "Please fill in all fields correctly.",
-    "timeout": "Request timed out. Please try again."
+    "timeout": "Request timed out. Please try again.",
+    "imgUploadSuccess": "Image upload completed successfully.",
+    "imgUploadFail": "An error occurred while uploading the image. Please try again."
+  },
+  "error": {
+    "timeout": "Request timed out. Please try again.",
+    "networkError": "Please check your network connection.",
+    "fileSizeError": "The maximum file size allowed is 20MB.",
+    "noImgToUpload": "Select an image file to insert.",
+    "imgInsertFail": "Failed to insert image. Please try again.",
+    "imgUploadFail": "An error occurred while uploading the image. Please try again.",
+    "invalidImageType": "Unsupported image format. Only JPG, PNG, BMP, WebP, and GIF are allowed."
   },
   "label": {
     "name": "Name",
@@ -94,7 +105,8 @@
     "revertConfirm": "Do you want to revert to the previous version? All current inputs will be lost.",
     "revertError": "An error occurred while reverting. Please try again.",
     "revertNoBackup": "No backup data available.",
-    "revertNoBackupForTab": "No backup data found for this tab."
+    "revertNoBackupForTab": "No backup data found for this tab.",
+    "imgUploader": "Image Uploader"
   },
   "editUserInfo": {
     "editUserInfoBtn": "Edit Name/Email",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -18,7 +18,18 @@
     "unknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.",
     "serverError": "서버 오류가 발생했습니다. 관리자에게 문의하세요.",
     "missingFields": "모든 칸에 내용을 정확하게 입력해 주세요.",
-    "timeout": "요청 시간이 초과되었습니다. 다시 시도해 주세요."
+    "timeout": "요청 시간이 초과되었습니다. 다시 시도해 주세요.",
+    "imgUploadSuccess": "사진 업로드가 완료되었습니다.",
+    "imgUploadFail": "사진 업로드 중 오류가 발생했습니다. 다시 시도해 주세요."
+  },
+  "error": {
+    "timeout": "요청 시간이 초과되었습니다. 다시 시도해 주세요.",
+    "networkError": "네트워크 연결을 확인해 주세요.",
+    "fileSizeError": "업로드 가능한 최대 파일 용량은 20MB입니다.",
+    "noImgToUpload": "삽입할 이미지 파일을 선택해주세요.",
+    "imgInsertFail": "이미지 삽입에 실패했습니다. 다시 시도해 주세요.",
+    "imgUploadFail": "이미지 업로드 중 오류가 발생했습니다. 다시 시도해 주세요.",
+    "invalidImageType": "지원하지 않는 이미지 형식입니다. JPG, PNG, GIF, WebP, BMP만 업로드 가능합니다."
   },
   "label": {
     "name": "이름",
@@ -93,7 +104,8 @@
     "revertConfirm": "수정하기 전으로 되돌리시겠습니까? 현재 입력한 내용은 모두 사라집니다.",
     "revertError": "되돌리기 중 오류가 발생했습니다. 다시 시도해 주세요.",
     "revertNoBackup": "백업 데이터가 없습니다.",
-    "revertNoBackupForTab": "해당 탭의 백업 데이터를 찾을 수 없습니다."
+    "revertNoBackupForTab": "해당 탭의 백업 데이터를 찾을 수 없습니다.",
+    "imgUploader": "사진 올리기"
   },
   "editUserInfo": {
     "editUserInfoBtn": "이름/이메일 변경",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -10,26 +10,26 @@
     "noUser": "존재하지 않는 사용자입니다",
     "confirmLogout": "로그아웃 하시겠습니까?",
     "saveSuccess": "저장되었습니다.",
-    "saveFail": "저장 중 오류가 발생했습니다. 다시 시도해 주세요.",
     "loading": "불러오는 중...",
     "cancelConfirm": "변경 사항이 저장되지 않습니다. 정말로 취소하시겠습니까?",
     "passwordMismatch": "비밀번호가 일치하지 않습니다.",
+    "imgUploadSuccess": "사진 업로드가 완료되었습니다."
+  },
+  "error": {
+    "saveFail": "저장 중 오류가 발생했습니다. 다시 시도해 주세요.",
+    "timeout": "요청 시간이 초과되었습니다. 다시 시도해 주세요.",
     "networkError": "네트워크 연결을 확인해 주세요.",
     "unknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.",
     "serverError": "서버 오류가 발생했습니다. 관리자에게 문의하세요.",
     "missingFields": "모든 칸에 내용을 정확하게 입력해 주세요.",
-    "timeout": "요청 시간이 초과되었습니다. 다시 시도해 주세요.",
-    "imgUploadSuccess": "사진 업로드가 완료되었습니다.",
-    "imgUploadFail": "사진 업로드 중 오류가 발생했습니다. 다시 시도해 주세요."
-  },
-  "error": {
-    "timeout": "요청 시간이 초과되었습니다. 다시 시도해 주세요.",
-    "networkError": "네트워크 연결을 확인해 주세요.",
     "fileSizeError": "업로드 가능한 최대 파일 용량은 20MB입니다.",
     "noImgToUpload": "삽입할 이미지 파일을 선택해주세요.",
     "imgInsertFail": "이미지 삽입에 실패했습니다. 다시 시도해 주세요.",
     "imgUploadFail": "이미지 업로드 중 오류가 발생했습니다. 다시 시도해 주세요.",
-    "invalidImageType": "지원하지 않는 이미지 형식입니다. JPG, PNG, GIF, WebP, BMP만 업로드 가능합니다."
+    "invalidImageType": "지원하지 않는 이미지 형식입니다. JPG, PNG, GIF, WebP, BMP만 업로드 가능합니다.",
+    "revertError": "되돌리기 중 오류가 발생했습니다. 다시 시도해 주세요.",
+    "revertNoBackup": "백업 데이터가 없습니다.",
+    "revertNoBackupForTab": "해당 탭의 백업 데이터를 찾을 수 없습니다."
   },
   "label": {
     "name": "이름",
@@ -102,9 +102,6 @@
     "autoSaveInfo": "변경사항이 자동으로 저장됩니다.",
     "revert": "되돌리기",
     "revertConfirm": "수정하기 전으로 되돌리시겠습니까? 현재 입력한 내용은 모두 사라집니다.",
-    "revertError": "되돌리기 중 오류가 발생했습니다. 다시 시도해 주세요.",
-    "revertNoBackup": "백업 데이터가 없습니다.",
-    "revertNoBackupForTab": "해당 탭의 백업 데이터를 찾을 수 없습니다.",
     "imgUploader": "사진 올리기"
   },
   "editUserInfo": {

--- a/src/util/extractFileName.ts
+++ b/src/util/extractFileName.ts
@@ -1,0 +1,10 @@
+// const uniqueFilename = `${file.name}-${Date.now()}`;
+// const imageUrl = `https://storage.googleapis.com/easiest-cv/${uniqueFilename}`;
+// 이렇게 만들어진 문자열에서 역으로 파일명 추출하는 함수
+
+export default function extractFileName(url: string): string {
+  const lastSlashIndex = url.lastIndexOf("/");
+  const fullName = url.substring(lastSlashIndex + 1); // file.name-Date.now()
+  const lastDashIndex = fullName.lastIndexOf("-");
+  return fullName.substring(0, lastDashIndex);
+}


### PR DESCRIPTION
# 변경사항: 텍스트 에디터에 이미지 첨부 기능 추가 

## 문제 상황
기존 ReactQuill 에디터에서도 이미 이미지 첨부 기능을 지원하고 있다. 이미지 버튼만 추가하면 됐다. 
하지만 이 기능을 사용하면 이미지 파일이 base64로 인코딩되어 들어간다. DB에 쌓이면 아무래도 용량을 많이 잡아먹겠죠. 
그래서 프로필 사진이랑 PDF 파일에서 하던 대로 GCS에 이미지를 업로드하고 그 링크를 넣기로 했다. 

## 이미지 버튼에 핸들러 함수 연결 
`AdminEditor.tsx`
```
  const modules = useMemo(() => {
    return {
      toolbar: {
        container: [
...
          ["image"],
          [{ align: [] }, { color: [] }, { background: [] }],
        ],
        handlers: {
          image: handleClickImage,
        },
```

image에 handlers 함수를 연결하면 이미지 버튼을 클릭했을 때 기존 기능 대신 이 핸들러 함수가 실행된다. 

이를 위해 컴포넌트 밖에 있던 `modules` 변수 선언을 컴포넌트 내부로 들여오고, 
함수 초기화 전에는 사용 못 하니 `handleClickImage` 함수 초기화 뒤에 위치시켜야 했다. 

### 매 렌더링마다 새 객체 생성 이슈: `useMemo`로 해결 
```
# Unhandled Runtime Error
TypeError: Cannot read properties of undefined (reading 'delta')

## Call Stack
### ReactQuill.componentDidUpdate
node_modules\react-quill\lib\index.js (174:1)
```

ReactQuill에서 `modules` 객체가 매번 새로 생성되면서 발생하는 문제. 그동안은 modules가 컴포넌트 밖에 있어서 안 그랬는데. 
React에서 객체를 컴포넌트 내부에서 직접 정의하면, 렌더링할 때마다 새로운 참조가 만들어진다. 
그래서 ReactQuill이 렌더링마다 매번 새 객체를 참조해야 해서 혼란 발생. 

참조 안정성을 위해 useMemo를 사용했다. 
의존성 배열에 빈 배열을 넣어 처음 한 번만 실행되게 한다. 그래서 처음에 한 번만 객체가 생성되고, 이후로는 메모이제이션되어 렌더링 시마다 기존에 저장해 둔 값을 참조하게 된다. 

## `ImageUploader` 컴포넌트
- 핸들러 함수 실행 시 ImageUploader Dialog가 열린다. 
- Input으로 이미지 업로드 시 미리보기를 제공한다. (`useEffect`로 저장된 이미지 url 클린업)

확인 버튼 누르면 
1. GCS에 업로드하는 API 호출 
2. 완료 후 해당 GCS 링크 이미지를 img 태그의 src에 넣어 `content`에 포함. 

### `refreshImages` 함수
처음에 이미지 갓 업로드했을 때 에디터에 엑박으로 뜨는 문제가 있었다. 다른 탭 갔다오면 잘 보이고. 
그래서 refreshImages 함수를 insertImage 함수 로직 맨 끝에 setTimeout 안에 넣었다. 
src를 재설정하고, 하는 김에 접근성을 고려해 alt도 추가했다. 링크에서 파일 이름을 추출해 alt로 삼았다. 
setTimeout 시간은 저기서 더 줄이면 가끔 그대로 엑박 뜨더라. 여유있게 잡았다 그래봤자 0.1초니까

### 파일 최대 용량 개당 20mb로 결정
10mb 정도로 해도 되겠지만, 웨딩사진이나 고화질 단체사진 같은 것도 웬만하면 넣을 수 있게 해주고 싶었다. 
어차피 지금은 비용도 안 나올 만큼 사용자가 없으니까. 나중에 줄일 수 있겠지. 

### 허용 이미지 형식에서 svg 제외 
> 모든 이미지 형식을 허용하면 악성 코드가 포함된 특수한 이미지 파일이나 위장된 파일들이 업로드될 위험이 있습니다. SVG는 특히 스크립트를 포함할 수 있어서 XSS 공격 벡터가 될 수 있습니다. 

...라고 클로드가 알려주길래. 
이미지 형식 에러 처리하다가 나온 거였다. 서버에서 모든 이미지 허용해주는 것보다 사용자한테 확장자 바꿔오라고 요구하는게 낫겠지? 하고 물어봤거든. 
svg 파일이 어떤 상황에서 쓰이는지 좀 더 물어보고, ECV 타깃층은 쓸 일 없겠다고 판단하고 제외했다. svg 로고? png로 바꿔오시기 바랍니다. 

이 서비스에서 보안이 좀 털려봤자 민감한 정보가 어딨겠냐는 안일한 생각을 반성했다. 저 생각을 못했네... 

# Others
- 번역 파일에서 errors 항목을 추가하고 네트워크에러 등 공통 에러들을 여기에 좀 모았다. 
- 현재까지 가장 최신의(?) 에러 처리 방법은 `ApiErrorResponse` type 사용하고, 프론트에서는 사용자가 해결할 수 있느냐, 없느냐로 나누어 판단하여 에러 메시지 띄우는 것. 에러 처리 방법이 계속 개선되고 있다 보니 전체 코드에서 에러처리 방법이 통일될 날이 오지 않을 것만 같다.

resolves #71 


