### PR TITLE
feat: GCS에서 파일 삭제 로직 추가, 디바운스 메모리 누수 개선 

### DIFF
--- a/src/app/api/contents/route.ts
+++ b/src/app/api/contents/route.ts
@@ -37,22 +37,10 @@ export async function PUT(request: Request) {
     const body: UpdateContentsRequest = await request.json();
     const { userid, tid, contents } = body;
 
-    const result1 = await query(
-      `SELECT contents FROM tabs WHERE userid = $1 and tid = $2`,
-      [userid, tid],
+    await query(
+      "UPDATE tabs SET contents = $1 WHERE userid = $2 and tid = $3",
+      [contents, userid, tid],
     );
-
-    if (result1.length) {
-      await query(
-        "UPDATE tabs SET contents = $1 WHERE userid = $2 and tid = $3",
-        [contents, userid, tid],
-      );
-    } else {
-      await query(
-        "INSERT INTO tabs (userid, tid, contents) VALUES ($1, $2, $3)",
-        [userid, tid, contents],
-      );
-    }
 
     return NextResponse.json({ message: "ok" });
   } catch (error: unknown) {

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+
+import { ApiErrorResponse } from "@/models/api";
+import { query } from "@/utils/database";
+import { deleteFile } from "@/utils/gcs";
+
+export async function DELETE(request: Request) {
+  const { userid, tid, newList } = await request.json();
+
+  if (!userid || tid === null || tid === undefined || !newList) {
+    const response: ApiErrorResponse = {
+      message: "필수 정보가 누락되었습니다.",
+      errorType: "VALIDATION_ERROR",
+    };
+    return NextResponse.json(response, { status: 400 });
+  }
+
+  try {
+    const oldListResult = await query<{ files: string[] }>(
+      "SELECT files FROM files WHERE userid = $1 and tid = $2",
+      [userid, tid],
+    );
+
+    if (!oldListResult || oldListResult.length === 0) {
+      // 파일 리스트가 없음
+      await query(
+        "INSERT INTO files (userid, tid, files) VALUES ($1, $2, $3)",
+        [userid, tid, newList],
+      );
+
+      return NextResponse.json(
+        { message: "Success to Insert New File List." },
+        { status: 201 },
+      );
+    } else {
+      // 기존 파일 리스트 존재
+      const oldList = oldListResult[0].files;
+
+      const filesToDelete = oldList.filter((file) => !newList.includes(file));
+
+      if (filesToDelete.length === 0) {
+        // 삭제할 파일이 없는 경우
+        await query(
+          "UPDATE files SET files = $1 WHERE userid = $2 and tid = $3",
+          [newList, userid, tid],
+        );
+
+        return NextResponse.json(
+          { message: "No files to delete. List updated." },
+          { status: 200 },
+        );
+      }
+
+      const failedList: string[] = [];
+
+      // 파일 삭제를 병렬로 처리하되 결과를 기다림
+      const deletePromises = filesToDelete.map(async (file) => {
+        try {
+          await deleteFile(file);
+          return { file, success: true };
+        } catch (error) {
+          console.error(`Failed to delete file ${file}:`, error);
+          return { file, success: false };
+        }
+      });
+
+      const results = await Promise.all(deletePromises);
+
+      // 실패한 파일들을 failedList에 추가
+      results.forEach(({ file, success }) => {
+        if (!success) {
+          failedList.push(file);
+        }
+      });
+
+      // 실패한 파일들은 다시 추가하여 DB에 유지
+      const finalList =
+        failedList.length > 0 ? [...newList, ...failedList] : newList;
+
+      await query(
+        "UPDATE files SET files = $1 WHERE userid = $2 and tid = $3",
+        [finalList, userid, tid],
+      );
+
+      const message =
+        failedList.length > 0
+          ? `Failed to delete ${failedList.length} files.`
+          : "Success to delete all orphan files.";
+
+      return NextResponse.json(
+        {
+          message,
+          deletedCount: filesToDelete.length - failedList.length,
+          failedCount: failedList.length,
+          failedFiles: failedList.length > 0 ? failedList : undefined,
+        },
+        { status: 200 },
+      );
+    }
+  } catch (error) {
+    console.error("DELETE API error:", error);
+
+    const errorMessage =
+      error instanceof Error ? error.message : "서버 내부 오류가 발생했습니다.";
+
+    const response: ApiErrorResponse = {
+      message: errorMessage,
+      errorType: "SERVER_ERROR",
+    };
+
+    return NextResponse.json(response, { status: 500 });
+  }
+}

--- a/src/app/components/admin/AdminEditor.tsx
+++ b/src/app/components/admin/AdminEditor.tsx
@@ -36,6 +36,7 @@ export default function AdminEditor({ userid, tid }: Props) {
 
   const { saveStatus, setSaveStatus, handleRevert, handleContentChange } =
     useAutoSave({
+      userid,
       tid,
       mutateUploadIntro,
       updateContents,
@@ -89,7 +90,6 @@ export default function AdminEditor({ userid, tid }: Props) {
 
       <ImageUploader
         userid={userid}
-        tid={tid}
         isOpen={isImageUploaderOpen}
         onClose={() => setIsImageUploaderOpen(false)}
         onImageInsert={handleImageInsert}

--- a/src/app/components/admin/ImageUploader.tsx
+++ b/src/app/components/admin/ImageUploader.tsx
@@ -15,7 +15,6 @@ import { useTabs } from "@/hooks/useTabs";
 
 interface ImageUploaderProps {
   userid: string;
-  tid: number;
   isOpen: boolean;
   onClose: () => void;
   onImageInsert: (imgTag: string) => void;

--- a/src/models/tab.model.ts
+++ b/src/models/tab.model.ts
@@ -5,3 +5,9 @@ export interface Tab {
   torder: number;
   contents: string | null;
 }
+
+export interface GCSRefreshRequest {
+  userid: string;
+  tid: number;
+  newList: string[];
+}

--- a/src/utils/gcs.ts
+++ b/src/utils/gcs.ts
@@ -7,6 +7,9 @@ const storage = new Storage({
 
 const bucket = storage.bucket("easiest-cv");
 
+// 이하 함수들에서 parameter로 받는 filename은 모두
+// `${file.name}-${Date.now()}` 형식
+
 export const uploadFile = async (
   filename: string,
   buffer: Buffer,

--- a/src/utils/parseImgSrc.ts
+++ b/src/utils/parseImgSrc.ts
@@ -1,0 +1,12 @@
+export const parseImgSrc = (htmlString: string): string[] => {
+  const imgRegex = /<img[^>]+src="?([^">]+)"?/g;
+
+  const srcList: string[] = [];
+  let match;
+  while ((match = imgRegex.exec(htmlString)) !== null) {
+    const fileName = match[1].split("/").pop() as string; // Date까지 포함한 유니크파일네임
+    srcList.push(fileName);
+  }
+
+  return srcList;
+};

--- a/src/utils/useDebounce.ts
+++ b/src/utils/useDebounce.ts
@@ -1,20 +1,33 @@
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useEffect } from "react";
 
-const useDebounce = <T extends unknown[]>(
+export default function useDebounce<T extends unknown[]>(
   callback: (...args: T) => void | Promise<void>,
   delay: number,
-) => {
+) {
   const timeoutRef = useRef<NodeJS.Timeout>();
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return useCallback(
     (...args: T) => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      timeoutRef.current = setTimeout(() => callback(...args), delay);
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current(...args);
+      }, delay);
     },
-    [callback, delay],
+    [delay],
   );
-};
-
-export default useDebounce;
+}


### PR DESCRIPTION
# GCS에서 파일 삭제 로직 추가

resolves #79 

## 기존 상황 
### 이슈
[텍스트 에디터에 이미지 첨부 기능 추가](https://github.com/SihyeonHong/EasiestCV/pull/80) 를 하였으나, 여기서 삭제는 구현하지 않음. 
에디터에서 이미지를 업로드했다가 추후 삭제하더라도 GCS에는 여전히 남아서 용량을 차지하게 됨. 

한편 텍스트 에디터의 수정사항은 마지막 keydown 2초 후 자동저장. 

### 접근 
파일명을 파라미터로 받아 GCS에서 파일을 삭제하는 `deleteFile()` 함수는 이미 `gcs.ts`에 구현되어있다. 프로필 사진과 pdf 파일을 다룰 때 기존 파일을 삭제하기 위해 사용도 하고 있다. 

## 해결 

### DB에 `files` 테이블 생성
```
CREATE TABLE files (
    userid VARCHAR(50) NOT NULL,
    tid INTEGER,
    files TEXT[],
    PRIMARY KEY (userid, tid)
);
```

현재 탭 `contents`에 첨부된 이미지 목록 
추후 이미지 외의 파일도 첨부가 가능하도록 확장될 가능성을 고려해 이름을 file로 지음. 
### 현재 탭에 첨부된 파일 목록 추출
`parseImgSrc.ts` 
htmlString을 파라미터로 받아서 srcList 리턴하는 함수. 

`useAutoSave.ts` 에서 텍스트 업데이트 후 `parseImgSrc()` 함수 실행해서 현재 탭에 있는 파일 목록을 뽑고
그 결과를  `/files` API로 보낸다. 

###  `/files` API: 파일 목록 비교 
1. DB의 files 테이블에서 oldList 가져옴
2. `useAutoSave`에서 보낸 현재 에디터의 newList와 비교 
3. new에 없는 건 GCS에서 삭제 
4. DB 테이블 최신화 (이로써 새로 업로드된 파일도 DB 리스트에 올라감) 


# 디바운스 메모리 누수 개선 

## 기존 코드와 문제점
```
  return useCallback(
    (...args: T) => {
      if (timeoutRef.current) {
        clearTimeout(timeoutRef.current);
      }
      timeoutRef.current = setTimeout(() => callback(...args), delay);
    },
    [callback, delay],
  );
```
`[callback, delay]` 의존성 배열이 문제. 
매번 새로운 콜백 함수가 전달되면 useCallback이 새로운 함수를 생성. 
컴포넌트가 언마운트되어도 이전 타이머들이 정리되지 않을 수 있다. 

## 수정
```
  const timeoutRef = useRef<NodeJS.Timeout>();
  const callbackRef = useRef(callback);

  // 콜백을 ref에 저장하여 의존성에서 제거
  useEffect(() => {
    callbackRef.current = callback;
  });

  // 컴포넌트 언마운트 시 타이머 정리
  useEffect(() => {
    return () => {
      if (timeoutRef.current) {
        clearTimeout(timeoutRef.current);
      }
    };
  }, []);

  return useCallback(
    (...args: T) => {
      if (timeoutRef.current) {
        clearTimeout(timeoutRef.current);
      }
      timeoutRef.current = setTimeout(() => {
        callbackRef.current(...args);
      }, delay);
    },
    [delay], // callback 의존성 제거
  );
```
- 콜백함수를 ref에 저장하여 의존성 제거
- 컴포넌트 언마운트 시 타이머 정리하는 로직 추가 

# Others

- `tab.model.ts`: `GCSRefreshRequest` 타입 추가 
- `gcs.ts`: filename 형식 알려주는 주석 추가 

## 쿼리 간소화 리팩터링
`/api/contents/route.ts`
예전 코드에서는 기존에 있는지 확인하고 없으면 insert 있으면 update해야 했는데, 지금은 그럴 필요 없음 tid를 request로 받아오는 거니까 무조건 있음. 그래서 update만 남김. 
이거 이렇게 바뀐 지 오래됐는데 이제서야 발견했지 뭐야 그동안 쓸데없이 쿼리 두 번 날리고 있었음. 

