### PR TITLE
모바일 레이아웃 수정 

### DIFF
--- a/src/app/[locale]/[userid]/page.tsx
+++ b/src/app/[locale]/[userid]/page.tsx
@@ -24,7 +24,7 @@ export default async function Page({ params }: Props) {
     <div className="flex flex-col items-center">
       <LogoutHandler />
       <Header type="public" />
-      <div className="flex w-full justify-center px-4">
+      <div className="flex w-full">
         <div className="w-full max-w-[1024px]">
           <Title title={user?.username || params.userid} />
           {!user ? <NoUserPage /> : <PublicTabs userid={params.userid} />}

--- a/src/app/components/UsageGuide.tsx
+++ b/src/app/components/UsageGuide.tsx
@@ -7,12 +7,12 @@ export default function UsageGuide() {
     <div className="flex flex-col gap-1">
       <h5 className="text-lg font-bold">{t("try")}</h5>
       <span className="inline-flex items-center gap-1">
-        <p className="text-sm">{t("checkOut")}</p>
+        <p className="text-nowrap text-sm">{t("checkOut")}</p>
         <a
-          href="https://easiest-cv.vercel.app/tutorial"
+          href="https://easiest-cv.com/tutorial"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sm text-blue-500 hover:underline"
+          className="text-nowrap text-sm text-blue-500 hover:underline"
         >
           {t("professorCV")}
         </a>

--- a/src/app/components/admin/AdminEditor.tsx
+++ b/src/app/components/admin/AdminEditor.tsx
@@ -10,8 +10,6 @@ import { useHome } from "@/hooks/useHome";
 import { useTabs } from "@/hooks/useTabs";
 import { Tab } from "@/models/tab.model";
 
-import "react-quill/dist/quill.snow.css";
-
 const ReactQuillComponent = dynamic(() => import("react-quill"), {
   ssr: false,
 });

--- a/src/app/components/admin/TabCancel.tsx
+++ b/src/app/components/admin/TabCancel.tsx
@@ -19,7 +19,9 @@ export default function TabCancel({ resetTabs }: { resetTabs: () => void }) {
   return (
     <AlertDialog>
       <AlertDialogTrigger>
-        <Button variant="secondary">{tButton("cancel")}</Button>
+        <Button variant="secondary" className="w-full">
+          {tButton("cancel")}
+        </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>{tMessage("cancelConfirm")}</AlertDialogHeader>

--- a/src/app/components/admin/TabManager.tsx
+++ b/src/app/components/admin/TabManager.tsx
@@ -75,6 +75,51 @@ export default function TabManager({ userid }: TabManagerProps) {
     setLocalTabs(_tabs);
   };
 
+  // 모바일 터치 지원을 위한 핸들러들
+  const handleTouchStart = (index: number) => {
+    dragItem.current = index;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    e.preventDefault(); // 스크롤 방지
+
+    const touch = e.touches[0];
+    const elementBelow = document.elementFromPoint(
+      touch.clientX,
+      touch.clientY,
+    );
+
+    // 드래그 오버 중인 아이템 찾기
+    const dragOverElement = elementBelow?.closest("[data-drag-index]");
+    if (dragOverElement) {
+      const overIndex = parseInt(
+        dragOverElement.getAttribute("data-drag-index") || "0",
+      );
+      dragOverItem.current = overIndex;
+    }
+  };
+
+  const handleTouchEnd = () => {
+    handleSort();
+  };
+
+  const getDragHandlers = (index: number) => ({
+    // 마우스 이벤트 (기존)
+    draggable: true,
+    onDragStart: () => (dragItem.current = index),
+    onDragEnter: () => (dragOverItem.current = index),
+    onDragEnd: handleSort,
+    onDragOver: (e: React.DragEvent) => e.preventDefault(),
+
+    // 터치 이벤트 (모바일)
+    onTouchStart: () => handleTouchStart(index),
+    onTouchMove: (e: React.TouchEvent) => handleTouchMove(e),
+    onTouchEnd: handleTouchEnd,
+
+    // 데이터 속성 (터치 이벤트에서 사용)
+    "data-drag-index": index,
+  });
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -103,18 +148,7 @@ export default function TabManager({ userid }: TabManagerProps) {
           </TableHeader>
           <TableBody>
             {tabs.map((tab, idx) => (
-              <TableRow
-                key={idx}
-                draggable
-                onDragStart={() => {
-                  dragItem.current = idx;
-                }}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  dragOverItem.current = idx;
-                }}
-                onDragEnd={handleSort}
-              >
+              <TableRow key={idx} {...getDragHandlers(idx)}>
                 <TableCell>
                   <MdDragIndicator />
                 </TableCell>

--- a/src/app/components/admin/TabManager.tsx
+++ b/src/app/components/admin/TabManager.tsx
@@ -161,7 +161,7 @@ export default function TabManager({ userid }: TabManagerProps) {
           </Button>
         </form>
 
-        <DialogFooter>
+        <DialogFooter className="gap-2">
           <TabCancel resetTabs={resetTabs} />
           <Button variant="default" onClick={() => saveTabs()}>
             {tButton("save")}

--- a/src/app/components/common/Footer.tsx
+++ b/src/app/components/common/Footer.tsx
@@ -2,9 +2,14 @@ export default function Footer() {
   return (
     <div className="my-7 w-full">
       <hr className="mb-3 border-gray-600" />
-      <p className="text-right text-xs text-gray-600">
-        © 2023-2025 Easiest CV. All rights reserved.
-      </p>
+      <div className="pr-3">
+        <p className="text-right text-xs text-gray-600">
+          © 2023-2025 Easiest CV. All rights reserved.
+        </p>
+        <p className="text-right text-xs text-gray-600">
+          Contact: admin@easiest-cv.com
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/app/components/common/Title.tsx
+++ b/src/app/components/common/Title.tsx
@@ -1,6 +1,6 @@
 export default function Title({ title }: { title?: string }) {
   return (
-    <h1 className="mx-auto my-14 cursor-default text-center text-4xl font-bold">
+    <h1 className="mx-auto my-8 cursor-default text-center text-4xl font-bold sm:my-14">
       {title ? title.toUpperCase() : "Easiest CV"}
     </h1>
   );

--- a/src/app/components/public/PublicContents.tsx
+++ b/src/app/components/public/PublicContents.tsx
@@ -14,10 +14,10 @@ export default function PublicContents({ userid, tid }: Props) {
 
   return (
     <Card className="w-full">
-      <CardContent className="prose w-full dark:prose-invert">
+      <CardContent className="w-full">
         {content && (
           <div
-            className="ql-editor prose-headings:!text-inherit prose-p:!text-inherit"
+            className="ql-editor"
             dangerouslySetInnerHTML={{
               __html: content,
             }}
@@ -27,8 +27,3 @@ export default function PublicContents({ userid, tid }: Props) {
     </Card>
   );
 }
-
-//   <CardContent className="prose max-w-none dark:prose-invert">
-//     {content && (
-//       <div
-//         className="ql-editor prose-headings:!text-inherit prose-p:!text-inherit"

--- a/src/app/components/public/PublicHome.tsx
+++ b/src/app/components/public/PublicHome.tsx
@@ -15,7 +15,7 @@ export default function PublicHome({ homeData }: Props) {
     <Card>
       <CardContent className="flex flex-col items-center justify-center gap-5 md:flex-row md:items-start">
         {homeData.img && (
-          <CardContent className="flex-1">
+          <CardContent className="flex-1 p-0">
             <Image
               src={homeData.img}
               alt="profile-img"
@@ -28,7 +28,7 @@ export default function PublicHome({ homeData }: Props) {
           </CardContent>
         )}
         <CardContent
-          className="ql-editor prose max-w-none flex-1 dark:prose-invert prose-headings:!text-inherit prose-p:!text-inherit"
+          className="ql-editor max-w-none flex-1 p-0"
           dangerouslySetInnerHTML={{ __html: homeData.intro ?? "" }}
         />
       </CardContent>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,22 +27,3 @@
     @apply bg-background text-foreground;
   }
 }
-
-.ql-editor h1 {
-  @apply text-2xl font-semibold;
-}
-.ql-editor h2 {
-  @apply text-xl font-semibold;
-}
-.ql-editor h3 {
-  @apply text-lg font-semibold;
-}
-.ql-editor h4 {
-  @apply text-base font-semibold;
-}
-.ql-editor h5 {
-  @apply text-sm font-semibold;
-}
-.ql-editor h6 {
-  @apply text-xs font-semibold;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,7 @@
 import "@/app/globals.css";
+import "react-quill/dist/quill.snow.css";
+import "@/style/quill.css";
+
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,7 +3,7 @@ import { MetadataRoute } from "next";
 import { query } from "@/utils/database";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = "https://easiest-cv.vercel.app";
+  const baseUrl = "https://easiest-cv.com";
   const locales = ["ko", "en"];
 
   const fetchUsersFromDB = async () => {

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -76,7 +76,7 @@ export function useEditor({ onImageClick, tQuillTooltips }: UseEditorProps) {
     return {
       toolbar: {
         container: [
-          [{ header: [1, 2, 3, 4, 5, false] }],
+          [{ header: [1, 2, 3, 4, false] }],
           ["bold", "italic", "underline", "strike", "blockquote"],
           [
             { list: "ordered" },

--- a/src/style/quill.css
+++ b/src/style/quill.css
@@ -1,0 +1,40 @@
+@tailwind components;
+@tailwind utilities;
+
+.ql-editor h1 {
+  @apply mb-4 mt-6 text-2xl font-bold;
+}
+
+.ql-editor h2 {
+  @apply mb-3 mt-5 text-xl font-semibold;
+}
+
+.ql-editor h3 {
+  @apply mb-3 mt-4 text-lg font-semibold;
+}
+
+.ql-editor h4 {
+  @apply mb-2 mt-3 text-base font-semibold;
+}
+
+.ql-editor ul {
+  @apply my-2 pl-0;
+  list-style-type: disc;
+}
+
+.ql-editor ol {
+  @apply my-2 pl-0;
+  list-style-type: decimal;
+}
+
+.ql-editor li {
+  @apply pl-0 leading-6;
+}
+
+/* 중첩된 리스트의 들여쓰기도 조정 */
+.ql-editor ul ul,
+.ql-editor ol ol,
+.ql-editor ul ol,
+.ql-editor ol ul {
+  @apply pl-0;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ import tailwindcssAnimate from "tailwindcss-animate";
 
 const tailwindConfig = {
   darkMode: ["class"],
-  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}", "./src/**/*.css"],
   theme: {
     extend: {
       borderRadius: {


### PR DESCRIPTION
# 모바일 레이아웃 개선
- 전반적으로 padding 줄임 
- TabManager에서 DialogFooter 내 버튼들 사이즈 버그 수정
- Title 상하 마진 줄임
- prose 제거 
- 탭 순서변경 드래그 앤 드롭 안 되는 이슈: 터치 이벤트 추가 
- heading 5 삭제, heading 1 font-weight 더 줬음. heading에 상하 마진 추가. 

# Refactor
- globals.css에서 quill.css 파일 분리 
- layout.tsx에 css문 import 추가 
- css 파일에서도 tailwind 문법 사용할 수 있도록 config 파일 수정


resolves #

# Others
- UserGuide에서 `text-nowrap` 추가하고 바뀐 도메인으로 링크 수정
- Footer에 이메일 주소 추가 

admin@easiest-cv.com 도메인 기반 메일 생겼음 
