### PR TITLE
다국어 설정 자동화 (v0.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easiest-cv",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "easiest-cv",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@google-cloud/storage": "^7.10.2",
         "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easiest-cv",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/robot.txt
+++ b/public/robot.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://www.easiest-cv.com/sitemap.xml

--- a/src/app/components/admin/TabManager.tsx
+++ b/src/app/components/admin/TabManager.tsx
@@ -135,6 +135,9 @@ export default function TabManager({ userid }: TabManagerProps) {
           <DialogDescription>
             {tAdmin("tabManagerDescription")}
           </DialogDescription>
+          <DialogDescription>
+            {tAdmin("tabManagerDescriptionMobile")}
+          </DialogDescription>
         </DialogHeader>
 
         <Table>

--- a/src/app/components/common/LocaleSwitcher.tsx
+++ b/src/app/components/common/LocaleSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useLocale } from "next-intl";
+import { useEffect } from "react";
 
 import { Button } from "@/app/components/common/Button";
 import { usePathname, useRouter } from "@/i18n/routing";
@@ -10,9 +11,20 @@ export default function LocaleSwitcher() {
   const pathname = usePathname();
   const currentLocale = useLocale();
 
+  useEffect(() => {
+    // 페이지 로드 시 로컬 스토리지 확인
+    const storedLocale = localStorage.getItem("ecv_locale");
+
+    // 저장된 언어가 현재 URL의 언어와 다르면 리디렉션
+    if (storedLocale && storedLocale !== currentLocale) {
+      router.replace(pathname, { locale: storedLocale });
+    }
+  }, [currentLocale, pathname, router]);
+
   const handleLocaleChange = () => {
     const newLocale = currentLocale === "en" ? "ko" : "en";
-    router.push(pathname, { locale: newLocale });
+    localStorage.setItem("ecv_locale", newLocale);
+    router.replace(pathname, { locale: newLocale });
   };
 
   return (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -90,6 +90,7 @@
     "imgPending": "Uploading image. Please wait...",
     "tabManager": "Manage Tabs",
     "tabManagerDescription": "Drag up and down to change the order of tabs.",
+    "tabManagerDescriptionMobile": "On mobile, press and hold a tab, then move it up or down.",
     "tabName": "Tab Name",
     "tabOrder": "Index",
     "actions": "Action",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -89,6 +89,7 @@
     "imgPending": "이미지 업로드 중입니다. 잠시만 기다려 주세요.",
     "tabManager": "탭 관리",
     "tabManagerDescription": "위아래로 드래그하면 탭의 순서를 바꿀 수 있습니다.",
+    "tabManagerDescriptionMobile": "모바일에서는 탭을 꾹 누른 후 위아래로 움직이면 됩니다.",
     "tabName": "탭 이름",
     "tabOrder": "순서",
     "actions": "관리",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,19 +6,35 @@ import { routing } from "@/i18n/routing";
 
 const intlMiddleware = createMiddleware(routing);
 
-export default async function middleware(request: NextRequest) {
-  const pathname = request.nextUrl.pathname;
+export default function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
 
-  if (
-    pathname === "/" ||
-    (!pathname.startsWith(`/${routing.defaultLocale}`) &&
-      !pathname.startsWith("/ko"))
-  ) {
-    const newUrl = new URL(`/${routing.defaultLocale}${pathname}`, request.url);
-    return NextResponse.redirect(newUrl);
+  // 사용자가 이미 로케일이 포함된 URL을 방문했다면, 미들웨어가 알아서 처리합니다.
+  const isLocaleInUrl = routing.locales.some(
+    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
+  );
+  if (isLocaleInUrl) {
+    return intlMiddleware(request);
   }
 
-  return intlMiddleware(request);
+  // 로케일이 없는 URL인 경우, 사용자의 브라우저 언어를 감지합니다.
+  const acceptLanguage = request.headers.get("Accept-Language");
+  const userLanguage = acceptLanguage
+    ? acceptLanguage.split(",")[0].split("-")[0]
+    : routing.defaultLocale;
+
+  // 지원하는 언어 목록에 사용자의 언어가 있는지 확인합니다.
+  const detectedLocale =
+    routing.locales.find((locale) => locale === userLanguage) ||
+    routing.defaultLocale;
+
+  // 감지된 언어로 리디렉션합니다.
+  const newUrl = new URL(
+    `/${detectedLocale}${pathname.startsWith("/") ? "" : "/"}${pathname}`,
+    request.url,
+  );
+
+  return NextResponse.redirect(newUrl);
 }
 
 export const config = {


### PR DESCRIPTION
# 다국어 설정 자동화 (v0.2.0)

## 주요 변경사항

### 시스템 언어설정 감지 
`middleware.ts`
- 이미 locale 포함된 URL이라면 해당 언어로 바로 연결 
- locale 없는 URL인 경우 다음 절차로 언어 결정하여 redirect: 
  - `Accept-Language` 헤더 읽어서 사용자의 브라우저 언어를 감지
  - 지원하는 언어 목록에 사용자의 언어가 있는지 확인하고, 없으면 `defaultLocale`로 결정 

## 브라우저에서 언어설정 기억하기 
`LocaleSwitcher.tsx`
- 언어 변경 시, 로컬스토리지에 설정된 언어 저장. 
- 페이지 로드 시, `useEffect`에서 로컬스토리지에 저장된 언어와 현재 url의 언어가 같은지 확인하고, 다르면 `router.replace`로 리디렉션. 

# 기타 
- 모바일에서 탭 순서 변경할 때는 탭을 꾹 누른 뒤 움직여야 한다는 설명 추가. 
- `robot.txt` 에 sitemap 추가. 

resolves #95 


