### PR TITLE
feat: 회원가입 시 페이퍼 탭에 템플릿 적용

### DIFF
--- a/public/papers-template.html
+++ b/public/papers-template.html
@@ -1,0 +1,53 @@
+<h1>Publications</h1>
+
+<h2>Journal Articles</h2>
+<ul>
+  <li>
+    <p><strong>Author Name</strong>, Co-author Name, "Paper Title,"</p>
+  </li>
+  <li>
+    <p>
+      <strong>Author Name</strong>, "Another Paper Title,"
+      <em>Journal Name</em>, vol. X, no. Y, pp. Z-Z, Year.
+    </p>
+  </li>
+</ul>
+
+<h2>Conference Papers</h2>
+<ul>
+  <li>
+    <p>
+      <strong>Author Name</strong>, Co-author Name, "Conference Paper Title," in
+      <em>Conference Name</em>, Location, Year, pp. Z-Z.
+    </p>
+  </li>
+  <li>
+    <p>
+      <strong>Author Name</strong>, "Another Conference Paper," in
+      <em>Conference Name</em>, Location, Year, pp. Z-Z.
+    </p>
+  </li>
+</ul>
+
+<h2>Books and Book Chapters</h2>
+<ul>
+  <li>
+    <p><strong>Author Name</strong>, <em>Book Title</em>, Publisher, Year.</p>
+  </li>
+  <li>
+    <p>
+      <strong>Author Name</strong>, "Chapter Title," in <em>Book Title</em>,
+      Editor Name, Ed., Publisher, Year, ch. X, pp. Y-Z.
+    </p>
+  </li>
+</ul>
+
+<h2>Preprints</h2>
+<ul>
+  <li>
+    <p>
+      <strong>Author Name</strong>, Co-author Name, "Preprint Title,"
+      <em>arXiv preprint</em> arXiv:XXXX.XXXXX, Year.
+    </p>
+  </li>
+</ul>

--- a/src/app/[locale]/tester/page.tsx
+++ b/src/app/[locale]/tester/page.tsx
@@ -1,14 +1,35 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
 import Footer from "@/app/components/common/Footer";
 import Header from "@/app/components/common/Header";
 import Title from "@/app/components/common/Title";
-import LoadingPage from "@/app/components/LoadingPage";
+import PublicContents from "@/app/components/public/PublicContents";
+import { normalizeHtmlWhitespace } from "@/utils/sanitize";
 
-export default function Tester() {
+export default async function Tester() {
+  // papers-template.html 파일 읽기
+  let testContent = "";
+  try {
+    const papersTemplatePath = join(
+      process.cwd(),
+      "public",
+      "papers-template.html",
+    );
+    testContent = normalizeHtmlWhitespace(
+      readFileSync(papersTemplatePath, "utf-8"),
+    );
+  } catch (error) {
+    console.error("papers-template.html 파일 읽기 실패:", error);
+    testContent = "<p>papers-template.html을 불러올 수 없습니다.</p>";
+  }
+
   return (
     <div>
       <Header />
       <Title title="테스트용 화면입니다" />
-      <LoadingPage />
+      <h3 className="mb-2 text-lg font-semibold">papers-template.html 내용:</h3>
+      <PublicContents content={testContent} />
       <Footer />
     </div>
   );

--- a/src/app/api/contents/route.ts
+++ b/src/app/api/contents/route.ts
@@ -8,12 +8,12 @@ export async function GET(request: Request) {
     const userId = searchParams.get("userid");
     const tid = searchParams.get("tid");
 
-    const result = await query<{ contents: string | null }>(
+    const result = await query<{ contents: string }>(
       "SELECT contents FROM tabs WHERE userid = $1 AND tid = $2",
       [userId, tid],
     );
 
-    return NextResponse.json(result.length > 0 ? result[0].contents : null);
+    return NextResponse.json(result.length > 0 ? result[0].contents : "");
   } catch (error: unknown) {
     if (error instanceof Error) {
       console.log("server error: ", error);

--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
 import bcrypt from "bcrypt";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -6,6 +9,7 @@ import { ReturnedTid } from "@/types/tab";
 import { SignupRequest } from "@/types/user-account";
 import { query } from "@/utils/database";
 import makeUserSiteMeta from "@/utils/makeUserSiteMeta";
+import { normalizeHtmlWhitespace } from "@/utils/sanitize";
 
 export async function POST(request: NextRequest) {
   try {
@@ -41,10 +45,26 @@ export async function POST(request: NextRequest) {
       [defaultMeta.userid, defaultMeta.title, defaultMeta.description],
     );
 
+    // 템플릿 파일 읽기 및 정규화
+    let templateContent = "";
+    try {
+      const templatePath = join(
+        process.cwd(),
+        "public",
+        "papers-template.html",
+      );
+      const rawTemplate = readFileSync(templatePath, "utf-8");
+      // HTML 정규화: 태그 사이의 공백 제거하여 tiptap 에디터 형식과 일치시킴
+      templateContent = normalizeHtmlWhitespace(rawTemplate);
+    } catch (error) {
+      console.error("템플릿 파일 읽기 실패:", error);
+      // 템플릿 파일을 읽지 못해도 계속 진행 (빈 문자열 사용)
+    }
+
     // 새 탭 1개 생성: DB가 자동생성해준 tid 받아서 slug 업데이트
     const generatedTid: ReturnedTid = await query(
-      "INSERT INTO tabs (userid, tname, torder, slug) VALUES ($1, $2, $3, $4) RETURNING tid",
-      [userid, "Tab1", 0, ""],
+      "INSERT INTO tabs (userid, tname, torder, slug, contents) VALUES ($1, $2, $3, $4, $5) RETURNING tid",
+      [userid, "Papers", 0, "", templateContent],
     );
     if (generatedTid && generatedTid[0]?.tid) {
       await query("UPDATE tabs SET slug = $1 WHERE tid = $2", [


### PR DESCRIPTION
# Features

회원가입 시 기본적으로 생성되는 탭 이름을 Papers로 바꾸고, 그 내용으로 예시 템플릿을 넣었습니다. 
예시 템플릿은 public의 `papers-template.html`에서 수정할 수 있습니다. 

sanitize.ts 파일 안에 tiptap 에디터에서 작성한 것과 같은 형식으로 html 파일에서 공백과 줄바꿈 등을 제거해 정규화하는 유틸함수를 추가했습니다. 

# Resolved

resolves #143 
